### PR TITLE
fix unexpected exception when relocate same operands.

### DIFF
--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -503,10 +503,10 @@ class Emitter(object):
             if not (opd.spec & (_REG_AR | _REG_BR)):
                 raise AssembleError('{} can not be a read operand'.format(opd))
 
-            if raddr_a is None:
+            if raddr_a is None or raddr_a == opd.addr:
                 raddr_a = opd.addr
                 muxes[i] = _INPUT_MUXES['A']
-            elif small_imm is None and raddr_b is None:
+            elif (small_imm is None and raddr_b is None) or raddr_b == opd.addr:
                 raddr_b = opd.addr
                 muxes[i] = _INPUT_MUXES['B']
             else:


### PR DESCRIPTION
This valid asm causes AssembleError.
~~~~
mov(r1, vpm, set_flags=True).mov(r3, 1.0, cond='nc')
~~~~
~~~~
videocore.assembler.AssembleError: Failed to locate operand vpm
~~~~

When we try to locate same operand to raddr_a/b more than twice,
instruction emitter accepts only first one and rejects second one unexpectedly.