### PR TITLE
Assemble without compile

### DIFF
--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -1156,20 +1156,14 @@ def qpu(f):
     def decorate(f):
         def decorated(asm, *args, **kwargs):
             g = f.__globals__
-            exec('\n'.join(
-                'g["{0}"] = asm._REGISTERS[\'{0}\']'.format(reg)
-                for reg in Assembler._REGISTERS
-            ))
-            exec('g["ra"] = [{}]\ng["rb"] = [{}]'.format(
-                ','.join('g["ra'+str(i)+'"]' for i in range(32)),
-                ','.join('g["rb'+str(i)+'"]' for i in range(32))
-            ))
-            exec('\n'.join(
-                'g["{0}"] = asm.{0}'.format(f)
-                for f in dir(Assembler)
-                if f[0] != '_'
-            ))
-            exec('g["L"] = asm.L')
+            for reg in Assembler._REGISTERS:
+                g[str(reg)] = asm._REGISTERS[str(reg)]
+            g['ra'] = [g['ra{}'.format(i)] for i in range(32)]
+            g['rb'] = [g['rb{}'.format(i)] for i in range(32)]
+            for i in dir(Assembler):
+                if i[0] != '_':
+                    g[str(i)] = getattr(asm, str(i))
+            g['L'] = asm.L
             f(asm, *args, **kwargs)
         return decorated
 

--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -1179,11 +1179,12 @@ def print_qbin(program, file = sys.stdout, *args, **kwargs):
     'Print QPU program as .qbin.'
     if hasattr(program, '__call__'):
         program = assemble(program, *args, **kwargs)
-    code = memoryview(program).tobytes()
+        code = memoryview(program).tobytes()
+        code = map(ord, code) if type(code) is str else code
     assert(len(code) % 8 == 0)
-    for i in range(len(code) / 8):
+    for i in range(len(code) // 8):
         for j in range(7, -1, -1):
-            print("%08d" % int(bin(ord(code[i * 8 + j]))[2:]), end = ' ' if j != 0 else '', file = file)
+            print("%08d" % int(bin(code[i * 8 + j])[2:]), end = ' ' if j != 0 else '', file = file)
         print(file = file)
 
 def print_qhex(program, file = sys.stdout, *args, **kwargs):
@@ -1191,6 +1192,7 @@ def print_qhex(program, file = sys.stdout, *args, **kwargs):
     if hasattr(program, '__call__'):
         program = assemble(program, *args, **kwargs)
         code = memoryview(program).tobytes()
+        code = map(ord, code) if type(code) is str else code
     assert(len(code) % 8 == 0)
-    for c in zip(*[iter(map(ord, code))]*8):
+    for c in zip(*[iter(code)]*8):
         print("0x{3:02X}{2:02X}{1:02X}{0:02X}, 0x{7:02X}{6:02X}{5:02X}{4:02X},".format(*c))

--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -1091,38 +1091,6 @@ def sema_up(asm, sema_id):
 def sema_down(asm, sema_id):
     asm._emit_sema(1, sema_id)
 
-REGISTER_ALIASES = '\n'.join(
-    '{0} = asm._REGISTERS[\'{0}\']'.format(reg)
-    for reg in Assembler._REGISTERS
-    )
-
-REGISTER_ARRAY = 'ra = [{}]\nrb = [{}]'.format(
-        ','.join('ra'+str(i) for i in range(32)),
-        ','.join('rb'+str(i) for i in range(32))
-        )
-
-INSTRUCTION_ALIASES = '\n'.join(
-    '{0} = asm.{0}'.format(f)
-    for f in dir(Assembler)
-    if f[0] != '_'
-    )
-
-SETUP_ASM_ALIASES = ast.parse("""
-# Alias of registers.
-{register_aliases}
-{register_array}
-
-# Alias of instructions.
-{instruction_aliases}
-
-# Label
-L = asm.L
-""".format(
-        register_aliases=REGISTER_ALIASES,
-        register_array=REGISTER_ARRAY,
-        instruction_aliases=INSTRUCTION_ALIASES
-        ))
-
 def qpu(f):
     """Decorator for writing QPU assembly language.
 


### PR DESCRIPTION
This PR provides `@qpu` decorator without `ast.parse` and `compile`.

Inconveniently, current `@qpu` decorator hides file & line where raises `AssembleError`.
~~~~
Traceback (most recent call last):
  File "test.py", line 33, in <module>
    print_qbin(boilerplate, None, int_ops, 0, 0)
  File "/home/pi/py-videocore/videocore/assembler.py", line 1176, in print_qbin
    program = assemble(program, *args, **kwargs)
  File "/home/pi/py-videocore/videocore/assembler.py", line 1170, in assemble
    f(asm, *args, **kwargs)
  File "<qpu>", line 265, in boilerplate
  File "<qpu>", line 259, in int_ops
  File "/home/pi/py-videocore/videocore/assembler.py", line 848, in _emit_add
    return self._add._emit(*args, **kwargs)
  File "/home/pi/py-videocore/videocore/assembler.py", line 530, in _emit
    self._encode_read_operands(opd1, opd2)
  File "/home/pi/py-videocore/videocore/assembler.py", line 497, in _encode_read_operands
    raise AssembleError('Too many regfile A source operand')
videocore.assembler.AssembleError: Too many regfile A source operand
~~~~

By this PR, backtrace can keep this information.
~~~~
Traceback (most recent call last):
  File "test.py", line 33, in <module>
    print_qbin(boilerplate, None, int_ops, 0, 0)
  File "/home/pi/py-videocore/videocore/assembler.py", line 1149, in print_qbin
    program = assemble(program, *args, **kwargs)
  File "/home/pi/py-videocore/videocore/assembler.py", line 1143, in assemble
    f(asm, *args, **kwargs)
  File "/home/pi/py-videocore/videocore/assembler.py", line 1135, in decorated
    f(asm, *args, **kwargs)
  File "test.py", line 17, in boilerplate
    f(asm)
  File "/home/pi/py-videocore/videocore/assembler.py", line 1135, in decorated
    f(asm, *args, **kwargs)
  File "test.py", line 26, in int_ops
    bxor(null, ra0, ra1)
  File "/home/pi/py-videocore/videocore/assembler.py", line 848, in _emit_add
    return self._add._emit(*args, **kwargs)
  File "/home/pi/py-videocore/videocore/assembler.py", line 530, in _emit
    self._encode_read_operands(opd1, opd2)
  File "/home/pi/py-videocore/videocore/assembler.py", line 497, in _encode_read_operands
    raise AssembleError('Too many regfile A source operand')
videocore.assembler.AssembleError: Too many regfile A source operand
~~~~