### PR TITLE
 Enable to use rotate immediates as small immediates 

### DIFF
--- a/tests/test_assemble_errors.py
+++ b/tests/test_assemble_errors.py
@@ -185,6 +185,14 @@ def test_invalid_rotate_insn():
     assemble(invalid_rotate_insn)
 
 @qpu
+def invalid_rotate_as_simm(asm):
+    iadd(r0, -2).mov(r1, r1, rotate=-3)
+
+@raises(AssembleError)
+def test_invalid_rotate_as_simm():
+    assemble(invalid_rotate_as_simm)
+
+@qpu
 def unsupported_immediate(asm):
     ldi(r0, "Hello")
 

--- a/tests/test_rotate.py
+++ b/tests/test_rotate.py
@@ -137,3 +137,26 @@ def test_rotate_ra():
     for i in range(0, 16):
         Y_ref = list_half_rotate(X, i)
         assert np.alltrue(Y[15+i] == Y_ref)
+
+@qpu
+def rotate_as_simm(asm):
+    mov(r0, vpm)
+
+    mov(broadcast, 0)
+    nop()
+    mov(r1, -16).mov(r2, r0, rotate=r5)
+    mov(vpm, r1)
+    mov(vpm, r2)
+    for i in range(1, 16):
+        mov(r1, i-16).mov(r2, r0, rotate=i)
+        mov(vpm, r1)
+        mov(vpm, r2)
+
+def test_rotate_as_simm():
+    X = np.array([random.getrandbits(32) for i in range(16)]).astype(np.int32)
+    Y = run_code(rotate_as_simm, X, 16*2).astype(np.int32)
+    assert np.alltrue(Y[0] == -16)
+    assert np.alltrue(Y[1] == X)
+    for i in range(1, 16):
+        assert np.alltrue(Y[i * 2 + 0] == i-16)
+        assert np.alltrue(Y[i * 2 + 1] == list_full_rotate(X, i))

--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -639,6 +639,26 @@ class MulEmitter(Emitter):
                 raise AssembleError('Rotate operation is only available when'
                                     ' inputs are taken from r0-r4 or ra')
 
+            if use_imm:
+
+                # 'r5 rotate' represents -1.
+                # 'n-upward rotate' represents n-16.
+                # So these combinations can be used (1 <= n <= 15):
+                # +-----------+--------+
+                # | small imm | rotate |
+                # +-----------+--------+
+                # |    -16    |   r5   |
+                # |     -n    |   -n   |
+                # +-----------+--------+
+                # c.f. https://vc4-notes.tumblr.com/post/153467713064/
+
+                if rotate == REGISTERS['r5']:
+                    if raddr_b != _SMALL_IMM['-16']:
+                        raise AssembleError(
+                                'Conflict immediate value and r5 rotate')
+                elif raddr_b != _SMALL_IMM[str(rotate%16-16)]:
+                    raise AssembleError('Conflict immediate value and n rotate')
+
             if rotate == REGISTERS['r5']:
                 raddr_b = 48
             else:


### PR DESCRIPTION
This feature is inherently supported, but not checked for errors. This PR fixes that.