### PR TITLE
driver: Fix to use bus address for QPU

### DIFF
--- a/videocore/driver.py
+++ b/videocore/driver.py
@@ -46,10 +46,10 @@ class Memory(object):
             if self.handle == 0:
                 raise DriverError('Failed to allocate QPU device memory')
 
-            self.baseaddr = self._to_phys(self.mailbox.lock_memory(self.handle))
-            fd = os.open('/dev/mem', os.O_RDWR|os.O_SYNC)
+            fd = os.open('/dev/vc4mem', os.O_RDWR|os.O_SYNC)
+            self.baseaddr = self.mailbox.lock_memory(self.handle)
             self.base = mmap.mmap(fd, size, mmap.MAP_SHARED, mmap.PROT_READ|mmap.PROT_WRITE,
-                    offset = self.baseaddr)
+                    offset = self._to_phys(self.baseaddr))
             os.close(fd)
         except:
             if self.base:
@@ -125,7 +125,7 @@ class Driver(object):
     def __exit__(self, exc_type, value, traceback):
         self.close()
         return exc_type is None
-    
+
     def copy(self, arr):
         new_arr = Array(
                 shape   = arr.shape,

--- a/videocore/driver.py
+++ b/videocore/driver.py
@@ -46,8 +46,8 @@ class Memory(object):
             if self.handle == 0:
                 raise DriverError('Failed to allocate QPU device memory')
 
-            fd = os.open('/dev/mem', os.O_RDWR|os.O_SYNC)
             self.baseaddr = self.mailbox.lock_memory(self.handle)
+            fd = os.open('/dev/mem', os.O_RDWR|os.O_SYNC)
             self.base = mmap.mmap(fd, size, mmap.MAP_SHARED, mmap.PROT_READ|mmap.PROT_WRITE,
                     offset = self._to_phys(self.baseaddr))
             os.close(fd)

--- a/videocore/driver.py
+++ b/videocore/driver.py
@@ -46,7 +46,7 @@ class Memory(object):
             if self.handle == 0:
                 raise DriverError('Failed to allocate QPU device memory')
 
-            fd = os.open('/dev/vc4mem', os.O_RDWR|os.O_SYNC)
+            fd = os.open('/dev/mem', os.O_RDWR|os.O_SYNC)
             self.baseaddr = self.mailbox.lock_memory(self.handle)
             self.base = mmap.mmap(fd, size, mmap.MAP_SHARED, mmap.PROT_READ|mmap.PROT_WRITE,
                     offset = self._to_phys(self.baseaddr))


### PR DESCRIPTION
The driver used physical address not only for `mmap` but also QPU. This PR fixes it.

c.f. https://github.com/nineties/py-videocore/issues/5