### PR TITLE
Add instrction check mechanism

### DIFF
--- a/tests/test_assemble_errors.py
+++ b/tests/test_assemble_errors.py
@@ -4,7 +4,7 @@ from nose.tools import raises, assert_raises
 from struct import pack
 from copy import deepcopy
 
-import videocore.assembler as A
+import videocore.encoding as enc
 from videocore.assembler import REGISTERS, AssembleError, assemble, qpu
 
 
@@ -26,23 +26,23 @@ def test_pack_unpack():
 
 #============================ Instruction encoding ============================
 
-SAMPLE_ALU_INSN = A.AluInsn(
+SAMPLE_ALU_INSN = enc.AluInsn(
     sig=0, unpack=1, pm=1, pack=2, cond_add=3, cond_mul=4, sf=1, ws=1,
     waddr_add=53, waddr_mul=12, op_mul=4, op_add=2, raddr_a=33, raddr_b=53,
     add_a=4, add_b=7, mul_a=6, mul_b=2
     )
 
-SAMPLE_BRANCH_INSN = A.BranchInsn(
+SAMPLE_BRANCH_INSN = enc.BranchInsn(
     sig=0xf, cond_br=13, rel=1, reg=0, raddr_a=27, ws=1, waddr_add=53,
     waddr_mul=12, immediate=0x12345678
     )
 
-SAMPLE_LOAD_INSN = A.LoadInsn(
+SAMPLE_LOAD_INSN = enc.LoadInsn(
     sig=0xe, unpack=1, pm=1, pack=2, cond_add=3, cond_mul=4, sf=1, ws=1,
     waddr_add=53, waddr_mul=12, immediate=0x12345678
     )
 
-SAMPLE_SEMA_INSN = A.SemaInsn(
+SAMPLE_SEMA_INSN = enc.SemaInsn(
     sig=0xe, unpack=4, pm=1, pack=2, cond_add=3, cond_mul=4, sf=1, ws=1,
     waddr_add=53, waddr_mul=12, sa=1, semaphore=13
     )
@@ -54,7 +54,7 @@ def test_equality():
 def test_bytes_conversion():
     for sample_insn in [SAMPLE_ALU_INSN, SAMPLE_BRANCH_INSN,
                         SAMPLE_LOAD_INSN, SAMPLE_SEMA_INSN]:
-        insn = A.Insn.from_bytes(sample_insn.to_bytes())
+        insn = enc.Insn.from_bytes(sample_insn.to_bytes())
         assert insn == sample_insn
 
 def test_insn_repr():

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -1,4 +1,4 @@
-from videocore.assembler import qpu, assemble
+from videocore.assembler import qpu, sanity_check
 
 @qpu
 def regfile_1(asm):
@@ -23,34 +23,7 @@ def delay_slot_1(asm):
   jzc(L.label1)
   exit()
 
-@qpu
-def mutex_1(asm):
-  mutex_acquire()
-  mutex_release()
-  exit()
-
-@qpu
-def label_1(asm):
-  L.label1
-  iadd (r0, r1, r2)
-  iadd (r0, r1, r2)
-  L.label2
-  iadd (r0, r1, r2, set_flags=False)
-  iadd (r0, r1, r2, set_flags=True)
-  jzc(L.label2)
-  nop(); nop(); nop()
-  exit()
-
-@qpu
-def semaphore_1(asm):
-  sema_up(0)
-  sema_up(1)
-  sema_down(1)
-  sema_down(0)
-  exit()
-
-assemble(regfile_1, sanity_check=True)
-assemble(composed_1, sanity_check=True)
-assemble(delay_slot_1, sanity_check=True)
-assemble(mutex_1, sanity_check=True)
-assemble(semaphore_1, sanity_check=True)
+def test_sanity_check():
+  assert (not sanity_check(regfile_1))
+  assert (not sanity_check(composed_1))
+  assert (not sanity_check(delay_slot_1))

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -1,0 +1,56 @@
+from videocore.assembler import qpu, assemble
+
+@qpu
+def regfile_1(asm):
+  iadd (ra0, r0, r1)
+  iadd (r0, ra0, r1)
+  exit()
+
+@qpu
+def composed_1(asm):
+  iadd (r0, r1, r2).v8min(r0, r1, r2)
+  exit()
+
+@qpu
+def delay_slot_1(asm):
+  L.label1
+  jzc(L.label1)
+  jzc(L.label1)
+  nop()
+  jzc(L.label1)
+  nop()
+  nop()
+  jzc(L.label1)
+  exit()
+
+@qpu
+def mutex_1(asm):
+  mutex_acquire()
+  mutex_release()
+  exit()
+
+@qpu
+def label_1(asm):
+  L.label1
+  iadd (r0, r1, r2)
+  iadd (r0, r1, r2)
+  L.label2
+  iadd (r0, r1, r2, set_flags=False)
+  iadd (r0, r1, r2, set_flags=True)
+  jzc(L.label2)
+  nop(); nop(); nop()
+  exit()
+
+@qpu
+def semaphore_1(asm):
+  sema_up(0)
+  sema_up(1)
+  sema_down(1)
+  sema_down(0)
+  exit()
+
+assemble(regfile_1, sanity_check=True)
+assemble(composed_1, sanity_check=True)
+assemble(delay_slot_1, sanity_check=True)
+assemble(mutex_1, sanity_check=True)
+assemble(semaphore_1, sanity_check=True)

--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -19,7 +19,10 @@ import ast
 import numbers
 
 import numpy
-
+from videocore.vinstr import AddInstr, MulInstr, LoadImmInstr, BranchInstr, SemaInstr, ComposedInstr
+from videocore.checker import check_main
+import videocore.encoding as enc
+from videocore.encoding import REGISTERS, Register, _INPUT_MUXES
 
 class _partialmethod(partial):
     'A descriptor for methods behaves like :py:class:`functools.partial.`'
@@ -29,284 +32,6 @@ class _partialmethod(partial):
 
 class AssembleError(Exception):
     'Exception related to QPU assembler'
-
-
-#============================== Encoding tables ===============================
-
-
-# Signaling bits.
-_SIGNAL = {
-    name: code
-    for code, name in enumerate([
-        'breakpoint', 'no signal', 'thread switch', 'thread end',
-        'wait scoreboard', 'unlock scoreboard', 'last thread switch',
-        'load coverage', 'load color', 'load color and thread end',
-        'load tmu0', 'load tmu1', 'load alpha', 'alu small imm', 'load',
-        'branch'
-    ])}
-
-# Add ALU instructions
-_ADD_INSN = {
-    name: code
-    for code, name in enumerate([
-        'nop', 'fadd', 'fsub', 'fmin', 'fmax', 'fminabs', 'fmaxabs', 'ftoi',
-        'itof', '', '', '', 'iadd', 'isub', 'shr', 'asr', 'ror', 'shl', 'imin',
-        'imax', 'band', 'bor', 'bxor', 'bnot', 'clz', '', '', '', '', '',
-        'v8adds', 'v8subs'
-    ]) if name
-    }
-
-# Mul ALU instructions
-_MUL_INSN = {
-    name: code
-    for code, name in enumerate([
-        'nop', 'fmul', 'imul24', 'v8muld', 'v8min', 'v8max', 'v8adds', 'v8subs'
-    ])}
-
-# Branch instructions
-_BRANCH_INSN = {
-    name: code
-    for code, name in enumerate([
-        'jzs', 'jzc', 'jzs_any', 'jzc_any', 'jns', 'jnc', 'jns_any', 'jnc_any',
-        'jcs', 'jcc', 'jcs_any', 'jcc_any', '', '', '', 'jmp'
-    ]) if name
-    }
-
-# Small immediate values.
-_SMALL_IMM = {
-    value: code
-    for code, value in enumerate(
-        [repr(i) for i in range(16)] +       # 0,1,2,..,15
-        [repr(i) for i in range(-16, 0)] +   # -16,-15,..,-1
-        [repr(2.0**i) for i in range(8)] +   # 1.0,2.0,..,128.0
-        [repr(2.0**i) for i in range(-8, 0)] # 1.0/256.0,1.0/128.0,..,1.0/2.0
-    )}
-_SMALL_IMM['0.0'] = 0     # 0.0 and 0 have same code
-
-# Condition codes.
-_COND = {
-    name: code
-    for code, name in enumerate([
-        'never', 'always', 'zs', 'zc', 'ns', 'nc', 'cs', 'cc'
-    ])}
-
-# Input multiplexers.
-# 'A' specifies raddr_a. 'B' specifies raddr_b.
-_INPUT_MUXES = {
-    'r0': 0, 'r1': 1, 'r2': 2, 'r3': 3, 'r4': 4, 'r5': 5, 'A': 6, 'B': 7
-    }
-
-# Packing. See Register.pack.
-_PACK = {
-    op: code
-    for code, op in enumerate([
-        'nop', '16a', '16b', 'rep 8', '8a', '8b', '8c', '8d', '32 sat',
-        '16a sat', '16b sat', 'rep 8 sat', '8a sat', '8b sat', '8c sat',
-        '8d sat'
-    ])}
-
-# Unpacking. See Register.unpack.
-_UNPACK = {
-    op: code
-    for code, op in enumerate([
-        'nop', '16a', '16b', 'rep 8d', '8a', '8b', '8c', '8d'
-    ])}
-
-# Mul ALU packing. See MulEmitter._emit.
-_MUL_PACK = {
-    'nop': 0,
-    'rep 8': 3,
-    '8a': 4 ,
-    '8b': 5,
-    '8c': 6,
-    '8d': 7
-    }
-
-#=================================== Register =================================
-
-
-# Flags to specify locations of registers.
-_REG_AR = 1 << 3   # Regfile A read location
-_REG_BR = 1 << 2   # Regfile B read location
-_REG_AW = 1 << 1   # Regfile A write location
-_REG_BW = 1 << 0   # Regfile B write location
-
-class Register(object):
-    """QPU Registers.
-
-    This class implements general purpuse registers, register mapped I/O
-    locations and accumulators.
-    """
-
-    def __init__(self, name, addr, spec, pack=0, unpack=0, pm=False):
-        self.name = name
-        self.addr = addr
-        self.spec = spec
-        self.pack_bits = pack
-        self.unpack_bits = unpack
-        self.pm_bit = pm
-
-    def __str__(self):
-        return self.name
-
-    def pack(self, op):
-        """Regfile-A pack.
-
-        Call in write locations like this.
-
-        >>> iadd(ra1.pack('16a'), ra0, rb0)
-
-        In case of this example, QPU converts the result of ra0 + rb0 to int16
-        then stores it to lower 16 bits of ra1.  The numbers and characters
-        (abcd) in operation codes specifies location of registers where the
-        packed bits to be stored. 'a' is for the least bits and 'd' for the
-        highest.
-
-        Operation codes with 'sat' suffix instruct to perform *saturation
-        arithmetic*.
-
-        :param op: One of the following strings to specify unpack operation.
-            * 'nop': no operation
-            * '16a', '16b':
-                Convert float32 to float16 for floating-point arithmetic, int32
-                to int16 for others.
-            * '8a', '8b', '8c', '8d':
-                Convert int32 to uint8.
-            * 'rep 8':
-                Convert int32 to uint8 then replicate it 4 times accross word.
-            * '32 sat', '16a sat', '16b sat', 'rep 8 sat', '8a sat', '8b sat',
-              '8c sat', '8d sat7:
-                Saturation arithmetic version of former codes.
-
-        See section 3 of the reference guide for details.
-        """
-
-        if (self.name in ['r0', 'r1', 'r2', 'r3', 'r4', 'r5'] or
-            not (self.spec & _REG_AW)):
-            raise AssembleError(
-                'Packing is only available for regfile-A write locations'
-                )
-
-        return Register(self.name, self.addr, _REG_AW, pack=_PACK[op], pm=0)
-
-    def unpack(self, op):
-        """Regfile-A unpack and r4 unpack.
-
-        Call in read locations like this.
-
-        >>> iadd(r0, ra0.unpack('16a'), rb0)
-
-        In case of this example, QPU converts int16, lower 16 bits of ra0, to
-        int32 before the addition.  The numbers and characters (abcd) in
-        operation codes indicate bits of registers to be converted.  'a' is for
-        the least bits and 'd' for the highest.
-
-        :param op: One of the following strings to indicate unpack operation.
-            * 'nop': no operation
-            * '16a', '16b':
-                Convert float16 to float32 for floating-point arithmetic, int16
-                to int32 for others.
-            * '8a', '8b', '8c', '8d':
-                Convert uint8 to float32 in range [0.0, 1.0] for floating-point
-                arithmetic, uint8 to int32 for others.
-            * 'rep 8d':
-                Replicate MS byte 4 times accores word.
-
-        See section 3 of the reference guide for details.
-        """
-
-        if self.name != 'r4' and not (self.spec & _REG_AR):
-            raise AssembleError(
-                'Unpacking is only available for regfile-A read locations'
-                ' and accumulator r4'
-                )
-
-        if self.name == 'r4':
-            spec = self.spec
-            pm = 1
-        else:
-            spec = _REG_AR
-            pm = 0
-
-        return Register(self.name, self.addr, spec, unpack=_UNPACK[op], pm=pm)
-
-# Table of registers
-
-# There are 32 general purpose registers in each regfile A and B.
-GENERAL_PURPOSE_REGISTERS = {
-    name: Register(
-        name, addr,
-        {'a': _REG_AR|_REG_AW,'b': _REG_BR|_REG_BW}[regfile]
-        )
-    for regfile in ['a', 'b']
-    for addr in range(32)
-    for name in ['r' + regfile + str(addr)]
-    }
-
-IO_REGISTERS = {
-    name: Register(name, addr, spec)
-    for name, addr, spec in [
-        ('uniform'           , 32 , _REG_AR|_REG_BR),
-        ('varying_read'      , 35 , _REG_AR|_REG_BR),
-        ('tmu_noswap'        , 36 , _REG_AW|_REG_BW),
-        ('r5_pix0'           , 37 , _REG_AW),
-        ('broadcast'         , 37 , _REG_BW),
-        ('host_interrupt'    , 38 , _REG_AW|_REG_BW),
-        ('element_number'    , 38 , _REG_AR),
-        ('qpu_number'        , 38 , _REG_BR),
-        ('null'              , 39 , _REG_AR|_REG_BR|_REG_AW|_REG_BW),
-        ('uniforms_address'  , 40 , _REG_AW),
-        ('x_pixel_coord'     , 41 , _REG_AR),
-        ('y_pixel_coord'     , 41 , _REG_BR),
-        ('quad_x'            , 41 , _REG_AW),
-        ('quad_y'            , 41 , _REG_BW),
-        ('ms_flags'          , 42 , _REG_AR|_REG_AW),
-        ('rev_flag'          , 42 , _REG_BR|_REG_BW),
-        ('tlb_stencil_setup' , 43 , _REG_AW|_REG_BW),
-        ('tlb_z'             , 44 , _REG_AW|_REG_BW),
-        ('tlb_color_ms'      , 45 , _REG_AW|_REG_BW),
-        ('tlb_color_all'     , 46 , _REG_AW|_REG_BW),
-        ('tlb_alpha_mask'    , 47 , _REG_AW|_REG_BW),
-        ('vpm'               , 48 , _REG_AR|_REG_BR|_REG_AW|_REG_BW),
-        ('vpm_ld_busy'       , 49 , _REG_AR),
-        ('vpm_st_busy'       , 49 , _REG_BR),
-        ('vpmvcd_rd_setup'   , 49 , _REG_AW),
-        ('vpmvcd_wr_setup'   , 49 , _REG_BW),
-        ('vpm_ld_wait'       , 50 , _REG_AR),
-        ('vpm_st_wait'       , 50 , _REG_BR),
-        ('vpm_ld_addr'       , 50 , _REG_AW),
-        ('vpm_st_addr'       , 50 , _REG_BW),
-        ('mutex'             , 51 , _REG_AR|_REG_BR|_REG_AW|_REG_BW),
-        ('sfu_recip'         , 52 , _REG_AW|_REG_BW),
-        ('sfu_recipsqrt'     , 53 , _REG_AW|_REG_BW),
-        ('sfu_exp2'          , 54 , _REG_AW|_REG_BW),
-        ('sfu_log2'          , 55 , _REG_AW|_REG_BW),
-        ('tmu0_s'            , 56 , _REG_AW|_REG_BW),
-        ('tmu0_t'            , 57 , _REG_AW|_REG_BW),
-        ('tmu0_r'            , 58 , _REG_AW|_REG_BW),
-        ('tmu0_b'            , 59 , _REG_AW|_REG_BW),
-        ('tmu1_s'            , 60 , _REG_AW|_REG_BW),
-        ('tmu1_t'            , 61 , _REG_AW|_REG_BW),
-        ('tmu1_r'            , 62 , _REG_AW|_REG_BW),
-        ('tmu1_b'            , 63 , _REG_AW|_REG_BW)
-    ]}
-
-ACCUMULATORS = {
-    name: Register(name, addr, spec)
-    for name, addr, spec in [
-        ('r0', 32, _REG_AW|_REG_BW),
-        ('r1', 33, _REG_AW|_REG_BW),
-        ('r2', 34, _REG_AW|_REG_BW),
-        ('r3', 35, _REG_AW|_REG_BW),
-        ('r4', -1, 0),
-        ('r5', -1, 0),
-    ]}
-
-REGISTERS = {}
-REGISTERS.update(GENERAL_PURPOSE_REGISTERS)
-REGISTERS.update(IO_REGISTERS)
-REGISTERS.update(ACCUMULATORS)
-
 
 #============================ Instruction encoding ============================
 
@@ -323,9 +48,9 @@ class Insn(Structure):
         'Decode string (or buffer object of length 64 bit) to instruction.'
         bytes, = unpack('Q', buf)
         sig = bytes >> 60
-        if sig == _SIGNAL['branch']:
+        if sig == enc._SIGNAL['branch']:
             return BranchInsn.from_buffer_copy(buf)
-        elif sig == _SIGNAL['load']:
+        elif sig == enc._SIGNAL['load']:
             if (bytes >> 57) & 0x7 == 4:
                 return SemaInsn.from_buffer_copy(buf)
             else:
@@ -404,9 +129,9 @@ class Emitter(object):
 
         pack_bits = add_dst.pack_bits or mul_dst.pack_bits
 
-        if add_dst.spec & _REG_AW and mul_dst.spec & _REG_BW:
+        if add_dst.spec & enc._REG_AW and mul_dst.spec & enc._REG_BW:
             return add_dst.addr, mul_dst.addr, False, pack_bits
-        elif mul_dst.spec & _REG_AW and add_dst.spec & _REG_BW:
+        elif mul_dst.spec & enc._REG_AW and add_dst.spec & enc._REG_BW:
             return add_dst.addr, mul_dst.addr, True, pack_bits
 
         raise AssembleError(
@@ -441,7 +166,7 @@ class Emitter(object):
 
         # Assign input muxes for accumulators.
         for i, opd in enumerate(operands):
-            if isinstance(opd, Register) and opd.name in ACCUMULATORS:
+            if isinstance(opd, Register) and opd.name in enc.ACCUMULATORS:
                 muxes[i] = _INPUT_MUXES[opd.name]
 
         if all(m is not None for m in muxes):
@@ -452,7 +177,7 @@ class Emitter(object):
         for i, opd in enumerate(operands):
             if muxes[i] is not None or not isinstance(opd, Register):
                 continue
-            if opd.spec & _REG_BR and not (opd.spec & _REG_AR):
+            if opd.spec & enc._REG_BR and not (opd.spec & enc._REG_AR):
                 if raddr_b is None:
                     raddr_b = opd.addr
                     muxes[i] = _INPUT_MUXES['B']
@@ -466,7 +191,7 @@ class Emitter(object):
             if muxes[i] is not None or isinstance(opd, Register):
                 continue
 
-            imm = _SMALL_IMM[repr(opd)]
+            imm = enc._SMALL_IMM[repr(opd)]
             if small_imm is None:
                 small_imm = imm
                 muxes[i] = _INPUT_MUXES['B']
@@ -487,7 +212,7 @@ class Emitter(object):
         for i, opd in enumerate(operands):
             if muxes[i] is not None:
                 continue
-            if opd.spec & _REG_AR and not (opd.spec & _REG_BR):
+            if opd.spec & enc._REG_AR and not (opd.spec & enc._REG_BR):
                 if raddr_a is None:
                     raddr_a = opd.addr
                     muxes[i] = _INPUT_MUXES['A']
@@ -500,7 +225,7 @@ class Emitter(object):
         for i, opd in enumerate(operands):
             if muxes[i] is not None: continue
 
-            if not (opd.spec & (_REG_AR | _REG_BR)):
+            if not (opd.spec & (enc._REG_AR | enc._REG_BR)):
                 raise AssembleError('{} can not be a read operand'.format(opd))
 
             if raddr_a is None or raddr_a == opd.addr:
@@ -534,9 +259,9 @@ class AddEmitter(Emitter):
                 raise AssembleError(
                         '\'{}\' can not be used with immediate'.format(sig))
             sig = 'alu small imm'
-        sig_bits = _SIGNAL[sig]
+        sig_bits = enc._SIGNAL[sig]
 
-        if op_add == _ADD_INSN['nop']:
+        if op_add == enc._ADD_INSN['nop']:
             set_flags = False
 
         waddr_add, waddr_mul, write_swap, pack = \
@@ -552,18 +277,20 @@ class AddEmitter(Emitter):
         elif pack and not unpack:
             pm = 0
 
-        cond_add = _COND[kwargs.get('cond', 'always')]
-        cond_mul = _COND['never']
+        cond_add = enc._COND[kwargs.get('cond', 'always')]
+        cond_mul = enc._COND['never']
 
         insn = AluInsn(
                 sig=sig_bits, unpack=unpack, pm=pm, pack=pack,
                 sf=set_flags, ws=write_swap, cond_add=cond_add,
-                cond_mul=cond_mul, op_add=op_add, op_mul=_MUL_INSN['nop'],
+                cond_mul=cond_mul, op_add=op_add, op_mul=enc._MUL_INSN['nop'],
                 waddr_add=waddr_add, waddr_mul=waddr_mul, raddr_a=raddr_a,
                 raddr_b=raddr_b, add_a=muxes[0], add_b=muxes[1],
                 mul_a=muxes[2], mul_b=muxes[3]
                 )
 
+        if self.asm.sanity_check:
+            insn.verbose = AddInstr(op_add, dst, opd1, opd2, sig, set_flags, cond_add)
         self.asm._emit(insn)
 
         # Create MulEmitter which holds arguments of Add ALU for dual
@@ -579,9 +306,9 @@ class MulEmitter(Emitter):
     This object receives arguments for Add ALU instruction at its construction
     to implement dual-issue of Add and Mul ALU.
     """
-    def __init__(self, asm, op_add=_ADD_INSN['nop'], add_dst=REGISTERS['null'],
+    def __init__(self, asm, op_add=enc._ADD_INSN['nop'], add_dst=REGISTERS['null'],
                  add_opd1=REGISTERS['r0'], add_opd2=REGISTERS['r0'],
-                 cond_add=_COND['never'], sig='no signal', set_flags=False,
+                 cond_add=enc._COND['never'], sig='no signal', set_flags=False,
                 increment=True):
         self.asm = asm
         self.op_add = op_add
@@ -596,7 +323,7 @@ class MulEmitter(Emitter):
     def _emit(self, op_mul, mul_dst=REGISTERS['null'], mul_opd1=REGISTERS['r0'],
             mul_opd2=REGISTERS['r0'], rotate=0, pack='nop', **kwargs):
 
-        mul_pack = _MUL_PACK[pack]
+        mul_pack = enc._MUL_PACK[pack]
 
         muxes, raddr_a, raddr_b, use_imm, unpack, read_pm = \
                 self._encode_read_operands(self.add_opd1, self.add_opd2,
@@ -632,7 +359,7 @@ class MulEmitter(Emitter):
                 raise AssembleError(
                         '\'{}\' can not be used with immediate'.format(sig))
             sig = 'alu small imm'
-        sig_bits = _SIGNAL[sig]
+        sig_bits = enc._SIGNAL[sig]
 
         if rotate:
             if muxes[2] == 5 or muxes[2] == 7 or muxes[3] == 5 or muxes[3] == 7:
@@ -645,7 +372,7 @@ class MulEmitter(Emitter):
                 raddr_b = 48 + rotate%16
 
         cond_add = self.cond_add
-        cond_mul = _COND[kwargs.get('cond', 'always')]
+        cond_mul = enc._COND[kwargs.get('cond', 'always')]
 
         insn = AluInsn(
                 sig=sig_bits, unpack=unpack, pm=pm, pack=pack,
@@ -655,6 +382,8 @@ class MulEmitter(Emitter):
                 raddr_b=raddr_b, add_a=muxes[0], add_b=muxes[1],
                 mul_a=muxes[2], mul_b=muxes[3]
                 )
+        if self.asm.sanity_check:
+            insn.verbose = MulInstr(op_mul, mul_dst, mul_opd1, mul_opd2, self.sig, self.set_flags, cond_mul)
         self.asm._emit(insn, increment=self.increment)
 
 class LoadEmitter(Emitter):
@@ -725,7 +454,7 @@ class LoadEmitter(Emitter):
 
         imm, unpack = self._encode_imm(imm)
 
-        cond_add = cond_mul = _COND[kwargs.get('cond', 'always')]
+        cond_add = cond_mul = enc._COND[kwargs.get('cond', 'always')]
         set_flags = kwargs.get('set_flags', False)
 
         insn = LoadInsn(
@@ -733,7 +462,8 @@ class LoadEmitter(Emitter):
                 cond_mul=cond_mul, sf=set_flags, ws=write_swap,
                 waddr_add=waddr_add, waddr_mul=waddr_mul, immediate=imm
                 )
-
+        if self.asm.sanity_check:
+            insn.verbose = LoadImmInstr(reg1, reg2, imm)
         self.asm._emit(insn)
 
 class Label(object):
@@ -770,8 +500,8 @@ class BranchEmitter(Emitter):
             raise AssembleError('Invalid branch target: {}'.format(target))
 
         if reg:
-            if (not (reg.spec & _REG_AR) or
-                reg.name not in GENERAL_PURPOSE_REGISTERS):
+            if (not (reg.spec & enc._REG_AR) or
+                reg.name not in enc.GENERAL_PURPOSE_REGISTERS):
                 raise AssembleError(
                     'Must be general purpose regfile A register {}'.format(reg)
                     )
@@ -793,7 +523,8 @@ class BranchEmitter(Emitter):
             raddr_a=raddr_a, ws=write_swap, waddr_add=waddr_add,
             waddr_mul=waddr_mul, immediate=imm
             )
-
+        if self.asm.sanity_check:
+            insn.verbose = BranchInstr(cond_br, target, reg, absolute, link)
         self.asm._emit(insn)
 
 class SemaEmitter(Emitter):
@@ -809,6 +540,8 @@ class SemaEmitter(Emitter):
             ws=0, waddr_add=null_addr, waddr_mul=null_addr, sa=sa,
             semaphore=sema_id)
 
+        if self.asm.sanity_check:
+            insn.verbose = SemaInstr(sa, sema_id)
         self.asm._emit(insn)
 
 
@@ -820,7 +553,7 @@ class Assembler(object):
 
     _REGISTERS = REGISTERS
 
-    def __init__(self):
+    def __init__(self, sanity_check=False):
         self._instructions = []
         self._program_counter = 0
         self._labels = []
@@ -833,6 +566,8 @@ class Assembler(object):
         self._sema = SemaEmitter(self)
         self.L = LabelEmitter(self)
 
+        self.sanity_check = sanity_check
+
     def _emit(self, insn, increment=True):
         """Emit new instruction ``insn`` if increment is True else replace the
         last instruction with ``insn``.
@@ -842,6 +577,9 @@ class Assembler(object):
             self._instructions.append(insn)
             self._program_counter += 8
         else:
+            add_op = self._instructions[-1]
+            if self.sanity_check:
+                insn.verbose = ComposedInstr (add_op.verbose, insn.verbose)
             self._instructions[-1] = insn
 
     def _emit_add(self, *args, **kwargs):
@@ -904,15 +642,15 @@ class Assembler(object):
 def alias(f):
     setattr(Assembler, f.__name__, f)
 
-for name, code in _ADD_INSN.items():
+for name, code in enc._ADD_INSN.items():
     setattr(Assembler, name, _partialmethod(Assembler._emit_add, code))
 
-for name, code in _MUL_INSN.items():
-    if name not in _ADD_INSN:
+for name, code in enc._MUL_INSN.items():
+    if name not in enc._ADD_INSN:
         setattr(Assembler, name, _partialmethod(Assembler._emit_mul, code))
     setattr(MulEmitter, name, _partialmethod(MulEmitter._emit, code))
 
-for name, code in _BRANCH_INSN.items():
+for name, code in enc._BRANCH_INSN.items():
     setattr(Assembler, name, _partialmethod(Assembler._emit_branch, code))
 
 Assembler.ldi = Assembler._emit_load
@@ -1139,8 +877,14 @@ def qpu(f):
 
 def assemble(f, *args, **kwargs):
     'Assemble QPU program to byte string.'
-    asm = Assembler()
+    if kwargs.get('sanity_check', None):
+        asm = Assembler(sanity_check=True)
+        del kwargs['sanity_check']
+    else:
+        asm = Assembler()
     f(asm, *args, **kwargs)
+    if asm.sanity_check:
+        check_main(asm._instructions)
     return asm._get_code()
 
 def print_qbin(program, file = sys.stdout, *args, **kwargs):

--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -277,7 +277,8 @@ class AddEmitter(Emitter):
         elif pack and not unpack:
             pm = 0
 
-        cond_add = enc._COND[kwargs.get('cond', 'always')]
+        cond_add_str = kwargs.get('cond', 'always')
+        cond_add = enc._COND[cond_add_str]
         cond_mul = enc._COND['never']
 
         insn = AluInsn(
@@ -290,7 +291,7 @@ class AddEmitter(Emitter):
                 )
 
         if self.asm.sanity_check:
-            insn.verbose = AddInstr(op_add, dst, opd1, opd2, sig, set_flags, cond_add)
+            insn.verbose = AddInstr(enc.ADD_INSN_REV[op_add], dst, opd1, opd2, sig, set_flags, cond_add_str)
         self.asm._emit(insn)
 
         # Create MulEmitter which holds arguments of Add ALU for dual
@@ -372,7 +373,8 @@ class MulEmitter(Emitter):
                 raddr_b = 48 + rotate%16
 
         cond_add = self.cond_add
-        cond_mul = enc._COND[kwargs.get('cond', 'always')]
+        cond_mul_str = kwargs.get('cond', 'always')
+        cond_mul = enc._COND[cond_mul_str]
 
         insn = AluInsn(
                 sig=sig_bits, unpack=unpack, pm=pm, pack=pack,
@@ -383,7 +385,7 @@ class MulEmitter(Emitter):
                 mul_a=muxes[2], mul_b=muxes[3]
                 )
         if self.asm.sanity_check:
-            insn.verbose = MulInstr(op_mul, mul_dst, mul_opd1, mul_opd2, self.sig, self.set_flags, cond_mul)
+            insn.verbose = MulInstr(enc.MUL_INSN_REV[op_mul], mul_dst, mul_opd1, mul_opd2, self.sig, self.set_flags, cond_mul_str)
         self.asm._emit(insn, increment=self.increment)
 
 class LoadEmitter(Emitter):
@@ -524,7 +526,7 @@ class BranchEmitter(Emitter):
             waddr_mul=waddr_mul, immediate=imm
             )
         if self.asm.sanity_check:
-            insn.verbose = BranchInstr(cond_br, target, reg, absolute, link)
+            insn.verbose = BranchInstr(enc.COND_REV[cond_br], target, reg, absolute, link)
         self.asm._emit(insn)
 
 class SemaEmitter(Emitter):

--- a/videocore/checker.py
+++ b/videocore/checker.py
@@ -1,0 +1,98 @@
+from videocore.vinstr import *
+from videocore.encoding import Register
+
+# helper functions
+
+def instruction_number(instrs, target):
+  return instrs.index(target)
+
+def print_with_indent(instr):
+  print ('    {}'.format(instr))
+
+def print_with_attension(instr):
+  print ('>>> {}'.format(instr))
+
+# TODO: print labels
+# labels are not stored in asm._instructions, but asm._labels (tuple label with its position)
+def print_instructions(instrs, indexes):
+  for index in indexes:
+    print_with_indent(instrs[index])
+
+def print_around(instrs, target):
+  index = instruction_number(instrs, target)
+  print_instructions(instrs, range (max (0, index-2), max (0, index)))
+  print_with_attension(target)
+  print_instructions(instrs, range (min (len(instrs), index), min (len(instrs), index + 2)))
+
+#================ check functions ======================================
+
+def check_branch_delay_slot(instrs):
+  for instr in instrs:
+    if (is_branch (instr)):
+      index = instrs.index(instr)
+      if len(instrs) < index + 3:
+        print ('warning: instructions of delay_slot is short?')
+        print_around(instrs, instr)
+      else:
+        delay_slot = instrs[index+1:index+4]
+
+        for item in delay_slot:
+          if (is_branch (item)):
+            print ('warning: branch is located in the position of delay_slot')
+            print_around(instrs, item)
+
+# TODO: check signals
+# writing to 'tmu0_s', and sending signal 'load tmu0' make invalid
+def check_composed(instrs):
+  for instr in instrs:
+    if (is_composed(instr)):
+      v = instr
+      if v.add_instr.dst == v.mul_instr.dst and v.add_instr.sig != 'thread end':
+        print ('warning: dst is the same register in the following composed-instruction')
+        print_around(instrs, instr)
+
+def check_regfile(instrs):
+  if len(instrs) == 1:
+    return
+
+  for index in range (0, len(instrs) - 1):
+    prev = instrs[index]
+    current = instrs[index+1]
+
+    outputs = []
+    inputs = []
+    def add(list, instr, f):
+      if f(instr) and isinstance (f(instr), Register):
+        list.append(f (instr))
+
+    if is_composed (prev):
+      add (outputs, prev.add_instr, lambda x: x.get_dst())
+      add (outputs, prev.mul_instr, lambda x: x.get_dst())
+    elif prev.get_dst():
+      add (outputs, prev, lambda x: x.get_dst())
+
+    if is_composed (current):
+      add (inputs, current.add_instr, lambda x: x.get_arg1())
+      add (inputs, current.add_instr, lambda x: x.get_arg2())
+      add (inputs, current.mul_instr, lambda x: x.get_arg1())
+      add (inputs, current.mul_instr, lambda x: x.get_arg2())
+    elif current.get_dst():
+      add (inputs, current, lambda x: x.get_arg1())
+      add (inputs, current, lambda x: x.get_arg2())
+
+    for out in outputs:
+      for read in inputs:
+        if enc.GENERAL_PURPOSE_REGISTERS.has_key(out.name) and  out.name == read.name:
+          print ('warning: regfile is read next to writing instruction')
+          print_around(instrs, current)
+
+all_checks = [check_composed, check_regfile, check_branch_delay_slot]
+
+def extract_verbose(instr):
+  return instr.verbose
+
+def check_main(instrs):
+  instrs = map(extract_verbose, instrs)
+  for check in all_checks:
+    check(instrs)
+  return

--- a/videocore/checker.py
+++ b/videocore/checker.py
@@ -82,7 +82,7 @@ def check_regfile(instrs):
 
     for out in outputs:
       for read in inputs:
-        if enc.GENERAL_PURPOSE_REGISTERS.has_key(out.name) and  out.name == read.name:
+        if enc.GENERAL_PURPOSE_REGISTERS.get(out.name, None) and  out.name == read.name:
           print ('warning: regfile is read next to writing instruction')
           print_around(instrs, current)
 
@@ -92,7 +92,7 @@ def extract_verbose(instr):
   return instr.verbose
 
 def check_main(instrs):
-  instrs = map(extract_verbose, instrs)
+  instrs = list (map(extract_verbose, instrs))
   for check in all_checks:
     check(instrs)
   return

--- a/videocore/driver.py
+++ b/videocore/driver.py
@@ -125,7 +125,7 @@ class Driver(object):
     def __exit__(self, exc_type, value, traceback):
         self.close()
         return exc_type is None
-    
+
     def copy(self, arr):
         new_arr = Array(
                 shape   = arr.shape,

--- a/videocore/encoding.py
+++ b/videocore/encoding.py
@@ -1,0 +1,287 @@
+#============================== Encoding tables ===============================
+
+# Signaling bits.
+_SIGNAL = {
+    name: code
+    for code, name in enumerate([
+        'breakpoint', 'no signal', 'thread switch', 'thread end',
+        'wait scoreboard', 'unlock scoreboard', 'last thread switch',
+        'load coverage', 'load color', 'load color and thread end',
+        'load tmu0', 'load tmu1', 'load alpha', 'alu small imm', 'load',
+        'branch'
+    ])}
+
+# Add ALU instructions
+_ADD_INSN = {
+    name: code
+    for code, name in enumerate([
+        'nop', 'fadd', 'fsub', 'fmin', 'fmax', 'fminabs', 'fmaxabs', 'ftoi',
+        'itof', '', '', '', 'iadd', 'isub', 'shr', 'asr', 'ror', 'shl', 'imin',
+        'imax', 'band', 'bor', 'bxor', 'bnot', 'clz', '', '', '', '', '',
+        'v8adds', 'v8subs'
+    ]) if name
+    }
+
+# Mul ALU instructions
+_MUL_INSN = {
+    name: code
+    for code, name in enumerate([
+        'nop', 'fmul', 'imul24', 'v8muld', 'v8min', 'v8max', 'v8adds', 'v8subs'
+    ])}
+
+
+# Branch instructions
+_BRANCH_INSN = {
+    name: code
+    for code, name in enumerate([
+        'jzs', 'jzc', 'jzs_any', 'jzc_any', 'jns', 'jnc', 'jns_any', 'jnc_any',
+        'jcs', 'jcc', 'jcs_any', 'jcc_any', '', '', '', 'jmp'
+    ]) if name
+    }
+
+
+# Small immediate values.
+_SMALL_IMM = {
+    value: code
+    for code, value in enumerate(
+        [repr(i) for i in range(16)] +       # 0,1,2,..,15
+        [repr(i) for i in range(-16, 0)] +   # -16,-15,..,-1
+        [repr(2.0**i) for i in range(8)] +   # 1.0,2.0,..,128.0
+        [repr(2.0**i) for i in range(-8, 0)] # 1.0/256.0,1.0/128.0,..,1.0/2.0
+    )}
+_SMALL_IMM['0.0'] = 0     # 0.0 and 0 have same code
+
+# Condition codes.
+_COND = {
+    name: code
+    for code, name in enumerate([
+        'never', 'always', 'zs', 'zc', 'ns', 'nc', 'cs', 'cc'
+    ])}
+
+
+# Input multiplexers.
+# 'A' specifies raddr_a. 'B' specifies raddr_b.
+_INPUT_MUXES = {
+    'r0': 0, 'r1': 1, 'r2': 2, 'r3': 3, 'r4': 4, 'r5': 5, 'A': 6, 'B': 7
+    }
+
+# Packing. See Register.pack.
+_PACK = {
+    op: code
+    for code, op in enumerate([
+        'nop', '16a', '16b', 'rep 8', '8a', '8b', '8c', '8d', '32 sat',
+        '16a sat', '16b sat', 'rep 8 sat', '8a sat', '8b sat', '8c sat',
+        '8d sat'
+    ])}
+
+# Unpacking. See Register.unpack.
+_UNPACK = {
+    op: code
+    for code, op in enumerate([
+        'nop', '16a', '16b', 'rep 8d', '8a', '8b', '8c', '8d'
+    ])}
+
+# Mul ALU packing. See MulEmitter._emit.
+_MUL_PACK = {
+    'nop': 0,
+    'rep 8': 3,
+    '8a': 4 ,
+    '8b': 5,
+    '8c': 6,
+    '8d': 7
+    }
+
+def rev(d):
+  return {v:k for k, v in d.items()}
+
+_SIGNAL_REV = rev(_SIGNAL)
+_ADD_INSN_REV = rev(_ADD_INSN)
+_MUL_INSN_REV = rev(_MUL_INSN)
+_BRANCH_INSN_REV = rev(_BRANCH_INSN)
+_COND_REV = rev(_COND)
+
+
+#=================================== Register =================================
+
+
+# Flags to specify locations of registers.
+_REG_AR = 1 << 3   # Regfile A read location
+_REG_BR = 1 << 2   # Regfile B read location
+_REG_AW = 1 << 1   # Regfile A write location
+_REG_BW = 1 << 0   # Regfile B write location
+
+class Register(object):
+    """QPU Registers.
+
+    This class implements general purpuse registers, register mapped I/O
+    locations and accumulators.
+    """
+
+    def __init__(self, name, addr, spec, pack=0, unpack=0, pm=False):
+        self.name = name
+        self.addr = addr
+        self.spec = spec
+        self.pack_bits = pack
+        self.unpack_bits = unpack
+        self.pm_bit = pm
+
+    def __str__(self):
+        return self.name
+
+    def pack(self, op):
+        """Regfile-A pack.
+
+        Call in write locations like this.
+
+        >>> iadd(ra1.pack('16a'), ra0, rb0)
+
+        In case of this example, QPU converts the result of ra0 + rb0 to int16
+        then stores it to lower 16 bits of ra1.  The numbers and characters
+        (abcd) in operation codes specifies location of registers where the
+        packed bits to be stored. 'a' is for the least bits and 'd' for the
+        highest.
+
+        Operation codes with 'sat' suffix instruct to perform *saturation
+        arithmetic*.
+
+        :param op: One of the following strings to specify unpack operation.
+            * 'nop': no operation
+            * '16a', '16b':
+                Convert float32 to float16 for floating-point arithmetic, int32
+                to int16 for others.
+            * '8a', '8b', '8c', '8d':
+                Convert int32 to uint8.
+            * 'rep 8':
+                Convert int32 to uint8 then replicate it 4 times accross word.
+            * '32 sat', '16a sat', '16b sat', 'rep 8 sat', '8a sat', '8b sat',
+              '8c sat', '8d sat7:
+                Saturation arithmetic version of former codes.
+
+        See section 3 of the reference guide for details.
+        """
+
+        if (self.name in ['r0', 'r1', 'r2', 'r3', 'r4', 'r5'] or
+            not (self.spec & _REG_AW)):
+            raise AssembleError(
+                'Packing is only available for regfile-A write locations'
+                )
+
+        return Register(self.name, self.addr, _REG_AW, pack=_PACK[op], pm=0)
+
+    def unpack(self, op):
+        """Regfile-A unpack and r4 unpack.
+
+        Call in read locations like this.
+
+        >>> iadd(r0, ra0.unpack('16a'), rb0)
+
+        In case of this example, QPU converts int16, lower 16 bits of ra0, to
+        int32 before the addition.  The numbers and characters (abcd) in
+        operation codes indicate bits of registers to be converted.  'a' is for
+        the least bits and 'd' for the highest.
+
+        :param op: One of the following strings to indicate unpack operation.
+            * 'nop': no operation
+            * '16a', '16b':
+                Convert float16 to float32 for floating-point arithmetic, int16
+                to int32 for others.
+            * '8a', '8b', '8c', '8d':
+                Convert uint8 to float32 in range [0.0, 1.0] for floating-point
+                arithmetic, uint8 to int32 for others.
+            * 'rep 8d':
+                Replicate MS byte 4 times accores word.
+
+        See section 3 of the reference guide for details.
+        """
+
+        if self.name != 'r4' and not (self.spec & _REG_AR):
+            raise AssembleError(
+                'Unpacking is only available for regfile-A read locations'
+                ' and accumulator r4'
+                )
+
+        if self.name == 'r4':
+            spec = self.spec
+            pm = 1
+        else:
+            spec = _REG_AR
+            pm = 0
+
+        return Register(self.name, self.addr, spec, unpack=_UNPACK[op], pm=pm)
+
+# Table of registers
+
+# There are 32 general purpose registers in each regfile A and B.
+GENERAL_PURPOSE_REGISTERS = {
+    name: Register(
+        name, addr,
+        {'a': _REG_AR|_REG_AW,'b': _REG_BR|_REG_BW}[regfile]
+        )
+    for regfile in ['a', 'b']
+    for addr in range(32)
+    for name in ['r' + regfile + str(addr)]
+    }
+
+IO_REGISTERS = {
+    name: Register(name, addr, spec)
+    for name, addr, spec in [
+        ('uniform'           , 32 , _REG_AR|_REG_BR),
+        ('varying_read'      , 35 , _REG_AR|_REG_BR),
+        ('tmu_noswap'        , 36 , _REG_AW|_REG_BW),
+        ('r5_pix0'           , 37 , _REG_AW),
+        ('broadcast'         , 37 , _REG_BW),
+        ('host_interrupt'    , 38 , _REG_AW|_REG_BW),
+        ('element_number'    , 38 , _REG_AR),
+        ('qpu_number'        , 38 , _REG_BR),
+        ('null'              , 39 , _REG_AR|_REG_BR|_REG_AW|_REG_BW),
+        ('uniforms_address'  , 40 , _REG_AW),
+        ('x_pixel_coord'     , 41 , _REG_AR),
+        ('y_pixel_coord'     , 41 , _REG_BR),
+        ('quad_x'            , 41 , _REG_AW),
+        ('quad_y'            , 41 , _REG_BW),
+        ('ms_flags'          , 42 , _REG_AR|_REG_AW),
+        ('rev_flag'          , 42 , _REG_BR|_REG_BW),
+        ('tlb_stencil_setup' , 43 , _REG_AW|_REG_BW),
+        ('tlb_z'             , 44 , _REG_AW|_REG_BW),
+        ('tlb_color_ms'      , 45 , _REG_AW|_REG_BW),
+        ('tlb_color_all'     , 46 , _REG_AW|_REG_BW),
+        ('tlb_alpha_mask'    , 47 , _REG_AW|_REG_BW),
+        ('vpm'               , 48 , _REG_AR|_REG_BR|_REG_AW|_REG_BW),
+        ('vpm_ld_busy'       , 49 , _REG_AR),
+        ('vpm_st_busy'       , 49 , _REG_BR),
+        ('vpmvcd_rd_setup'   , 49 , _REG_AW),
+        ('vpmvcd_wr_setup'   , 49 , _REG_BW),
+        ('vpm_ld_wait'       , 50 , _REG_AR),
+        ('vpm_st_wait'       , 50 , _REG_BR),
+        ('vpm_ld_addr'       , 50 , _REG_AW),
+        ('vpm_st_addr'       , 50 , _REG_BW),
+        ('mutex'             , 51 , _REG_AR|_REG_BR|_REG_AW|_REG_BW),
+        ('sfu_recip'         , 52 , _REG_AW|_REG_BW),
+        ('sfu_recipsqrt'     , 53 , _REG_AW|_REG_BW),
+        ('sfu_exp2'          , 54 , _REG_AW|_REG_BW),
+        ('sfu_log2'          , 55 , _REG_AW|_REG_BW),
+        ('tmu0_s'            , 56 , _REG_AW|_REG_BW),
+        ('tmu0_t'            , 57 , _REG_AW|_REG_BW),
+        ('tmu0_r'            , 58 , _REG_AW|_REG_BW),
+        ('tmu0_b'            , 59 , _REG_AW|_REG_BW),
+        ('tmu1_s'            , 60 , _REG_AW|_REG_BW),
+        ('tmu1_t'            , 61 , _REG_AW|_REG_BW),
+        ('tmu1_r'            , 62 , _REG_AW|_REG_BW),
+        ('tmu1_b'            , 63 , _REG_AW|_REG_BW)
+    ]}
+
+ACCUMULATORS = {
+    name: Register(name, addr, spec)
+    for name, addr, spec in [
+        ('r0', 32, _REG_AW|_REG_BW),
+        ('r1', 33, _REG_AW|_REG_BW),
+        ('r2', 34, _REG_AW|_REG_BW),
+        ('r3', 35, _REG_AW|_REG_BW),
+        ('r4', -1, 0),
+        ('r5', -1, 0),
+    ]}
+
+REGISTERS = {}
+REGISTERS.update(GENERAL_PURPOSE_REGISTERS)
+REGISTERS.update(IO_REGISTERS)
+REGISTERS.update(ACCUMULATORS)

--- a/videocore/encoding.py
+++ b/videocore/encoding.py
@@ -1,3 +1,9 @@
+
+
+
+class AssembleError(Exception):
+    'Exception related to QPU assembler'
+
 #============================== Encoding tables ===============================
 
 # Signaling bits.

--- a/videocore/vinstr.py
+++ b/videocore/vinstr.py
@@ -64,14 +64,14 @@ class AddInstr(InstrBase):
          enc._ADD_INSN_REV[self.op] == 'bor':
       return 'mutex_release'
 
-    if enc._ADD_INSN_REV[self.op] == 'nop':
+    if self.op == 'nop':
       s = 'nop'
     else :
-      s = '{}, {}, {}, {}'.format(enc._ADD_INSN_REV[self.op], self.dst, self.opd1, self.opd2)
+      s = '{}, {}, {}, {}'.format(self.op, self.dst, self.opd1, self.opd2)
     if self.set_flag:
       s += ' set_flag=True'
-    if not (self.cond == enc._COND['always']):
-      s += 'cond={}'.format(enc._CONV_REV[cond])
+    if not (self.cond == 'always'):
+      s += 'cond={}'.format(cond)
     return s
 
   def get_dst(self):
@@ -94,14 +94,14 @@ class MulInstr(InstrBase):
     self.cond = cond
 
   def __str__(self):
-    if enc._MUL_INSN_REV[self.op] == 'nop':
+    if self.op == 'nop':
       s = 'nop'
     else:
-      s = '{}, {}, {}, {}'.format(enc._MUL_INSN_REV[self.op], self.dst, self.opd1, self.opd2)
+      s = '{}, {}, {}, {}'.format(self.op, self.dst, self.opd1, self.opd2)
     if self.set_flag:
       s += ' set_flag=True'
-    if not (self.cond == enc._COND['always']):
-      s += 'cond={}'.format(enc._CONV_REV[self.cond])
+    if not (self.cond == 'always'):
+      s += 'cond={}'.format(self.cond)
     return s
 
   def get_dst(self):
@@ -144,7 +144,7 @@ class BranchInstr(InstrBase):
     self.link = link
 
   def __str__(self):
-    return '{}(L.{})'.format(enc._BRANCH_INSN_REV[self.cond_br], self.target.name)
+    return '{}(L.{})'.format(self.cond_br, self.target.name)
 
 class SemaInstr(InstrBase):
   def __init__(self, sa, sema_id):

--- a/videocore/vinstr.py
+++ b/videocore/vinstr.py
@@ -1,0 +1,183 @@
+import videocore.encoding as enc
+
+#=============================================================================
+# Verbose instruction definitions for sanity checks
+#=============================================================================
+
+def is_add(instr):
+  if not isinstance (instr, InstrBase):
+    assert(False)
+  return isinstance(instr, AddInstr)
+def is_mul(instr):
+  if not isinstance (instr, InstrBase):
+    assert(False)
+  return isinstance(instr, MulInstr)
+def is_loadimm(instr):
+  if not isinstance (instr, InstrBase):
+    assert(False)
+  return isinstance(instr, LoadImmInstr)
+def is_branch(instr):
+  if not isinstance (instr, InstrBase):
+    assert(False)
+  return isinstance(instr, BranchInstr)
+def is_sema(instr):
+  if not isinstance (instr, InstrBase):
+    assert(False)
+  return isinstance(instr, SemaInstr)
+def is_composed(instr):
+  if not isinstance (instr, InstrBase):
+    assert(False)
+  return isinstance(instr, ComposedInstr)
+
+class InstrBase(object):
+  def __init__():
+    return
+
+  def get_dst(self):
+    return None
+
+  def get_arg1(self):
+    return None
+
+  def get_arg2(self):
+    return None
+
+class AddInstr(InstrBase):
+  def __init__ (self, op, dst, opd1, opd2, sig, set_flag, cond):
+    self.op = op
+    self.dst = dst
+    self.opd1 = opd1
+    self.opd2 = opd2
+    self.sig = sig
+    self.set_flag = set_flag
+    self.cond = cond
+
+  def __str__(self):
+    if self.get_dst() == enc.REGISTERS['null'] and \
+       self.get_arg1() == enc.REGISTERS['mutex'] and \
+       self.get_arg2() == enc.REGISTERS['mutex'] and \
+       enc._ADD_INSN_REV[self.op] == 'bor':
+      return 'mutex_acquire'
+    elif self.get_dst() == enc.REGISTERS['mutex'] and \
+         self.get_arg1() == enc.REGISTERS['null'] and \
+         self.get_arg2() == enc.REGISTERS['null'] and \
+         enc._ADD_INSN_REV[self.op] == 'bor':
+      return 'mutex_release'
+
+    if enc._ADD_INSN_REV[self.op] == 'nop':
+      s = 'nop'
+    else :
+      s = '{}, {}, {}, {}'.format(enc._ADD_INSN_REV[self.op], self.dst, self.opd1, self.opd2)
+    if self.set_flag:
+      s += ' set_flag=True'
+    if not (self.cond == enc._COND['always']):
+      s += 'cond={}'.format(enc._CONV_REV[cond])
+    return s
+
+  def get_dst(self):
+    return self.dst
+
+  def get_arg1(self):
+    return self.opd1
+
+  def get_arg2(self):
+    return self.opd2
+
+class MulInstr(InstrBase):
+  def __init__ (self, op, dst, opd1, opd2, sig, set_flag, cond):
+    self.op = op
+    self.dst = dst
+    self.opd1 = opd1
+    self.opd2 = opd2
+    self.sig = sig
+    self.set_flag = set_flag
+    self.cond = cond
+
+  def __str__(self):
+    if enc._MUL_INSN_REV[self.op] == 'nop':
+      s = 'nop'
+    else:
+      s = '{}, {}, {}, {}'.format(enc._MUL_INSN_REV[self.op], self.dst, self.opd1, self.opd2)
+    if self.set_flag:
+      s += ' set_flag=True'
+    if not (self.cond == enc._COND['always']):
+      s += 'cond={}'.format(enc._CONV_REV[self.cond])
+    return s
+
+  def get_dst(self):
+    return self.dst
+
+  def get_arg1(self):
+    return self.opd1
+
+  def get_arg2(self):
+    return self.opd2
+
+class LoadImmInstr(InstrBase):
+  def __init__(self, reg1, reg2, imm):
+    self.reg1 = reg1
+    self.reg2 = reg2
+    self.imm = imm
+
+  def __str__(self):
+    s = 'ldi {}, {}'.format(self.reg1, self.imm)
+    if (self.reg2 != enc.REGISTERS['null']):
+      s += '; ldi {}, {}'.format(self.reg2, self.imm)
+    return s
+
+  def get_dst(self):
+    return self.reg1
+
+  def get_arg1(self):
+    return self.imm
+
+  def get_arg2(self):
+    return None
+
+
+class BranchInstr(InstrBase):
+  def __init__(self, cond_br, target, reg, absolute, link):
+    self.cond_br = cond_br
+    self.target = target
+    self.reg = reg
+    self.absolute = absolute
+    self.link = link
+
+  def __str__(self):
+    return '{}(L.{})'.format(enc._BRANCH_INSN_REV[self.cond_br], self.target.name)
+
+class SemaInstr(InstrBase):
+  def __init__(self, sa, sema_id):
+    self.sa = sa
+    self.sema_id = sema_id
+
+  def __str__(self):
+    if self.sa == 0:
+      s = 'sema_up'
+    else:
+      s = 'sema_down'
+    return '{}({})'.format(s, self.sema_id)
+
+class ComposedInstr(InstrBase):
+  def __init__(self, add, mul):
+    self.add_instr = add
+    self.mul_instr = mul
+
+  def __str__(self):
+    return str(self.add_instr) + '; ' + str(self.mul_instr)
+
+  def get_dst(self):
+    assert (False)
+
+  def get_arg1(self):
+    assert (False)
+
+  def get_arg2(self):
+    assert (False)
+
+class Label(InstrBase):
+  def __init__(self, name):
+    self.name = name
+
+  def __str__(self):
+    return ':' + self.name


### PR DESCRIPTION
This pullreq add instruction sanity checking mechanism for vc4.
My addition is:

- If `sanity_check=True` is passed to `Assembler`,  every instruction has field `verbose` to hold verbose instruction information.
- If `sanity_check=True` in `assemble` in `assemble.py`, instruction checking will work.

See `test/test_sanity_check.py` to know what effects my pullreq has added.