### PR TITLE
Remove dangerous default arguments

### DIFF
--- a/tests/test_assemble_errors.py
+++ b/tests/test_assemble_errors.py
@@ -245,3 +245,32 @@ def invalid_semaphore_insn(asm):
 
 def test_invalid_sema_insn():
     assert_raises(AssembleError, assemble, invalid_semaphore_insn)
+
+@qpu
+def missing_args3(asm):
+    mov (r0, r1)
+    nop().nop()
+    nop().nop(sig='load tmu0')
+    itof (r0, r1)
+    ftoi (r0, r1)
+    bnot (r0, r1)
+    clz (r0, r1)
+
+def test_missing_args1():
+    for name in enc._ADD_INSN:
+        if not enc._ADD_DEFAULT_ARGS.get(name):
+            @qpu
+            def f(asm):
+                name (r0, r0)
+            raises(TypeError, assemble, f)
+
+def test_missing_args2():
+    for name in enc._MUL_INSN:
+        if not enc._MUL_DEFAULT_ARGS.get(name):
+            @qpu
+            def f(asm):
+                name (r0, r0)
+            raises(TypeError, assemble, f)
+
+def test_missing_args3():
+    assert (assemble (missing_args3))

--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -172,8 +172,7 @@ class Emitter(object):
 class AddEmitter(Emitter):
     'Emitter of Add ALU instructions.'
 
-    def _emit(self, op_add, dst=REGISTERS['null'], opd1=REGISTERS['r0'],
-            opd2=REGISTERS['r0'], sig='no signal', set_flags=True, **kwargs):
+    def _emit(self, op_add, dst, opd1, opd2, sig='no signal', set_flags=True, **kwargs):
 
         muxes, raddr_a, raddr_b, use_imm, unpack, read_pm = \
                 self._encode_read_operands(opd1, opd2)
@@ -245,8 +244,7 @@ class MulEmitter(Emitter):
         self.set_flags = set_flags
         self.increment = increment
 
-    def _emit(self, op_mul, mul_dst=REGISTERS['null'], mul_opd1=REGISTERS['r0'],
-            mul_opd2=REGISTERS['r0'], rotate=0, pack='nop', **kwargs):
+    def _emit(self, op_mul, mul_dst, mul_opd1, mul_opd2, rotate=0, pack='nop', **kwargs):
 
         mul_pack = enc._MUL_PACK[pack]
 
@@ -508,11 +506,16 @@ class Assembler(object):
                 insn.verbose = ComposedInstr (add_op.verbose, insn.verbose)
             self._instructions[-1] = insn
 
-    def _emit_add(self, *args, **kwargs):
-        return self._add._emit(*args, **kwargs)
+    # _emit_XXX gives default arguments if needed
+    def _emit_add(self, add_op, *args, **kwargs):
+        l = enc._ADD_DEFAULT_ARGS.get(add_op, [])
+        args = list(args) + l
+        return self._add._emit(add_op, *args, **kwargs)
 
-    def _emit_mul(self, *args, **kwargs):
-        return self._mul._emit(*args, **kwargs)
+    def _emit_mul(self, mul_op, *args, **kwargs):
+        l = enc._MUL_DEFAULT_ARGS.get(mul_op, [])
+        args = list(args) + l
+        return self._mul._emit(mul_op, *args, **kwargs)
 
     def _emit_load(self, *args, **kwargs):
         return self._load._emit(*args, **kwargs)
@@ -574,7 +577,12 @@ for name, code in enc._ADD_INSN.items():
 for name, code in enc._MUL_INSN.items():
     if name not in enc._ADD_INSN:
         setattr(Assembler, name, _partialmethod(Assembler._emit_mul, code))
-    setattr(MulEmitter, name, _partialmethod(MulEmitter._emit, code))
+
+    # XXX bad trick: partial application only for nop in mul
+    if name == 'nop':
+        setattr(MulEmitter, name, _partialmethod(MulEmitter._emit, code, enc._r0, enc._r0, enc._r0))
+    else:
+        setattr(MulEmitter, name, _partialmethod(MulEmitter._emit, code))
 
 for name, code in enc._BRANCH_INSN.items():
     setattr(Assembler, name, _partialmethod(Assembler._emit_branch, code))

--- a/videocore/encoding.py
+++ b/videocore/encoding.py
@@ -292,6 +292,26 @@ REGISTERS.update(GENERAL_PURPOSE_REGISTERS)
 REGISTERS.update(IO_REGISTERS)
 REGISTERS.update(ACCUMULATORS)
 
+#============================ Default Arguments ============================
+
+
+_r0 = REGISTERS['r0']
+__d = _ADD_INSN
+
+_ADD_DEFAULT_ARGS = {
+    __d['nop']  : [_r0, _r0, _r0],
+    __d['itof'] : [_r0],
+    __d['ftoi'] : [_r0],
+    __d['bnot'] : [_r0],
+    __d['clz']  : [_r0]
+}
+
+__d = _MUL_INSN
+_MUL_DEFAULT_ARGS = {
+    __d['nop'] : [_r0, _r0, _r0]
+}
+
+
 #============================ Instruction encoding ============================
 
 

--- a/videocore/encoding.py
+++ b/videocore/encoding.py
@@ -1,5 +1,5 @@
-
-
+from ctypes import Structure, c_ulong, string_at, byref, sizeof
+from struct import pack, unpack
 
 class AssembleError(Exception):
     'Exception related to QPU assembler'


### PR DESCRIPTION
Default arguments of `AddEmitter` and `MulEmitter` made program dangerous.
Before this fix, `iadd (r0, r1)` was legal thanks to default arguments of `AddEmitter._emit` (`r0` is completed).
