### PR TITLE
Add some instruction checks

### DIFF
--- a/tests/test_assemble_errors.py
+++ b/tests/test_assemble_errors.py
@@ -245,3 +245,32 @@ def invalid_semaphore_insn(asm):
 
 def test_invalid_sema_insn():
     assert_raises(AssembleError, assemble, invalid_semaphore_insn)
+
+@qpu
+def missing_args3(asm):
+    mov (r0, r1)
+    nop().nop()
+    nop().nop(sig='load tmu0')
+    itof (r0, r1)
+    ftoi (r0, r1)
+    bnot (r0, r1)
+    clz (r0, r1)
+
+def test_missing_args1():
+    for name in enc._ADD_INSN:
+        if not enc._ADD_DEFAULT_ARGS.get(name):
+            @qpu
+            def f(asm):
+                name (r0, r0)
+            raises(TypeError, assemble, f)
+
+def test_missing_args2():
+    for name in enc._MUL_INSN:
+        if not enc._MUL_DEFAULT_ARGS.get(name):
+            @qpu
+            def f(asm):
+                name (r0, r0)
+            raises(TypeError, assemble, f)
+
+def test_missing_args3():
+    assert (assemble (missing_args3))

--- a/tests/test_check_util.py
+++ b/tests/test_check_util.py
@@ -1,0 +1,130 @@
+from videocore.assembler import Assembler, qpu
+import videocore.checker as checker
+import videocore.encoding as enc
+
+@qpu
+def prog1(asm):
+  mov (r1, r0)
+
+@qpu
+def prog2(asm):
+  mov (r1, r0).mov(r2, r3)
+
+@qpu
+def prog3(asm):
+  imul24(r0, r1, r2)
+
+def test_get_outputs1():
+  asm = Assembler(sanity_check=True)
+  prog1(asm)
+  v = asm._instructions[0].verbose
+  assert (len(checker.get_outputs(v)) == 1)
+  assert (checker.get_outputs(v)[0].name == 'r1')
+
+def test_get_outputs2():
+  asm = Assembler(sanity_check=True)
+  prog2(asm)
+  v = asm._instructions[0].verbose
+  assert (len(checker.get_outputs(v)) == 2)
+  assert (checker.get_outputs(v)[0].name == 'r1')
+  assert (checker.get_outputs(v)[1].name == 'r2')
+
+def test_get_outputs3():
+  asm = Assembler(sanity_check=True)
+  prog3(asm)
+  v = asm._instructions[0].verbose
+  assert (len(checker.get_outputs(v)) == 1)
+  assert (checker.get_outputs(v)[0].name == 'r0')
+
+def test_get_inputs1():
+  asm = Assembler(sanity_check=True)
+  prog1(asm)
+  v = asm._instructions[0].verbose
+  assert (len(checker.get_inputs(v)) == 2)
+  assert (checker.get_inputs(v)[0].name == 'r0')
+  assert (checker.get_inputs(v)[0].name == 'r0')
+
+def test_get_inputs2():
+  asm = Assembler(sanity_check=True)
+  prog2(asm)
+  v = asm._instructions[0].verbose
+  assert (len(checker.get_inputs(v)) == 4)
+  assert (checker.get_inputs(v)[0].name == 'r0')
+  assert (checker.get_inputs(v)[1].name == 'r0')
+  assert (checker.get_inputs(v)[2].name == 'r3')
+  assert (checker.get_inputs(v)[3].name == 'r3')
+
+def test_get_inputs3():
+  asm = Assembler(sanity_check=True)
+  prog3(asm)
+  v = asm._instructions[0].verbose
+  assert (len(checker.get_inputs(v)) == 2)
+  assert (checker.get_inputs(v)[0].name == 'r1')
+  assert (checker.get_inputs(v)[1].name == 'r2')
+
+def test_nexts1():
+  @qpu
+  def nexts(asm):
+    mov (r0, r1)
+    mov (r0, r2)
+
+  asm = Assembler(sanity_check=True)
+  nexts(asm)
+  xs, labels = checker.prepare(asm._instructions, asm._labels)
+  v = checker.get_nexts(xs[0], xs, labels, 1)
+  assert (len(v) == 1)
+  assert (v[0] == xs[1])
+
+def test_nexts2():
+  @qpu
+  def nexts(asm):
+    mov (r0, r1)
+    mov (r0, r2)
+    mov (r0, r3)
+
+  asm = Assembler(sanity_check=True)
+  nexts(asm)
+  xs, labels = checker.prepare(asm._instructions, asm._labels)
+  v = checker.get_nexts(xs[0], xs, labels, 2)
+  assert (len(v) == 1)
+  assert (v[0] == xs[2])
+
+def test_nexts3():
+  @qpu
+  def nexts(asm):
+    L.label1
+    jzc(L.label1)
+    nop()
+    nop()
+    mov(r0, r1)
+
+  asm = Assembler(sanity_check=True)
+  nexts(asm)
+  xs, labels = checker.prepare(asm._instructions, asm._labels)
+  v1 = checker.get_nexts(xs[3], xs, labels, 1)
+  assert (len(v1) == 1)
+  assert (v1[0] == xs[0])
+  v2 = checker.get_nexts(xs[3], xs, labels, 2)
+  assert (len(v2) == 1)
+  assert (v2[0] == xs[1])
+
+def test_nexts4():
+  @qpu
+  def nexts(asm):
+    L.label1
+    jzc(L.label1)
+    nop()
+    nop()
+    mov(r0, r1)
+    iadd(r0, ra0, r1)
+
+  asm = Assembler(sanity_check=True)
+  nexts(asm)
+  xs, labels = checker.prepare(asm._instructions, asm._labels)
+  v1 = checker.get_nexts(xs[3], xs, labels, 1)
+  assert (len(v1) == 2)
+  assert (v1[0] == xs[0])
+  assert (v1[1] == xs[4])
+  v2 = checker.get_nexts(xs[3], xs, labels, 2)
+  assert (len(v2) == 1)
+  assert (v2[0] == xs[1])

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -23,7 +23,20 @@ def delay_slot_1(asm):
   jzc(L.label1)
   exit()
 
+@qpu
+def regfile_2(asm):
+  L.label1
+  iadd (r0, ra0, r0)
+  jzc(L.label1)
+  nop()
+  nop()
+  iadd (ra0, r0, r0)
+  exit()
+
 def test_sanity_check():
   assert (not sanity_check(regfile_1))
   assert (not sanity_check(composed_1))
   assert (not sanity_check(delay_slot_1))
+  assert (not sanity_check(regfile_2))
+
+test_sanity_check()

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -70,6 +70,3 @@ def test_tmu_reg2():
 
   for name, prog in locals().items():
     assert (not sanity_check(prog))
-
-# test_sanity_check()
-test_tmu_reg2()

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -39,4 +39,37 @@ def test_sanity_check():
   assert (not sanity_check(delay_slot_1))
   assert (not sanity_check(regfile_2))
 
-test_sanity_check()
+def test_tmu_reg1():
+  @qpu
+  def tmu_reg1(asm):
+    mov (tmu0_s, r0)
+
+  for name, prog in locals().items():
+    assert (sanity_check(prog))
+
+def test_tmu_reg2():
+  @qpu
+  def tmu_reg1(asm):
+    mov (tmu0_s, r0, sig='load tmu0')
+
+  @qpu
+  def tmu_reg2(asm):
+    mov (tmu0_s, r0, sig='load tmu1')
+
+  @qpu
+  def tmu_reg3(asm):
+    mov (tmu1_s, r0, sig='load tmu0')
+
+  @qpu
+  def tmu_reg4(asm):
+    mov (tmu1_s, r0, sig='load tmu1')
+
+  @qpu
+  def tmu_reg5(asm):
+    mov (tmu0_s, r0).imul24(r0, r1, r2, sig='load tmu0')
+
+  for name, prog in locals().items():
+    assert (not sanity_check(prog))
+
+# test_sanity_check()
+test_tmu_reg2()

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -70,3 +70,105 @@ def test_tmu_reg2():
 
   for name, prog in locals().items():
     assert (not sanity_check(prog))
+
+def test_sfu1():
+  @qpu
+  def sfu1(asm):
+    iadd(sfu_exp2, r0, r1)
+    iadd(r0, r4, r0)
+
+  @qpu
+  def sfu2(asm):
+    iadd(sfu_exp2, r0, r1)
+    nop()
+    iadd(r0, r4, r0)
+
+  @qpu
+  def sfu3(asm):
+    L.label1
+    mov (r0, r4)
+    jzc(L.label1)
+    nop()
+    nop()
+    iadd(sfu_log2, r0, r1)
+
+  @qpu
+  def sfu4(asm):
+    L.label1
+    nop ()
+    mov (r0, r4)
+    jzc(L.label1)
+    nop()
+    nop()
+    iadd(sfu_log2, r0, r1)
+
+  @qpu
+  def sfu5(asm):
+    L.label1
+    mov (r0, r4)
+    jzc(L.label1)
+    nop()
+    iadd(sfu_log2, r0, r1)
+    nop()
+
+  @qpu
+  def sfu6(asm):
+    L.label1
+    nop()
+    jzc(L.label1)
+    nop()
+    nop()
+    iadd(sfu_log2, r0, r1)
+    mov (r0, r4)
+    nop()
+
+  for name, prog in locals().items():
+    assert (not sanity_check(prog))
+
+def test_sfu2():
+  @qpu
+  def sfu1(asm):
+    iadd(sfu_log2, r0, r1)
+    iadd(sfu_exp2, r0, r1)
+    nop()
+    nop()
+
+  @qpu
+  def sfu2(asm):
+    iadd(sfu_log2, r0, r1)
+    nop()
+    iadd(sfu_exp2, r0, r1)
+    nop()
+    nop()
+
+  @qpu
+  def sfu3(asm):
+    iadd(sfu_log2, r0, r1)
+    nop()
+    nop(sig='load tmu0')
+    nop()
+    nop()
+
+  @qpu
+  def sfu4(asm):
+    iadd(sfu_log2, r0, r1)
+    nop(sig='load tmu1')
+    nop()
+    nop()
+    nop()
+
+  for name, prog in locals().items():
+    assert (not sanity_check(prog))
+
+def test_sfu3():
+  @qpu
+  def sfu1(asm):
+    iadd(sfu_log2, r0, r1)
+    nop()
+    nop()
+    iadd(sfu_exp2, r0, r1)
+  for name, prog in locals().items():
+    assert (sanity_check(prog))
+
+test_sfu2()
+test_sfu3()

--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -317,7 +317,7 @@ class MulEmitter(Emitter):
                 mul_a=muxes[2], mul_b=muxes[3]
                 )
         if self.asm.sanity_check:
-            insn.verbose = MulInstr(enc._MUL_INSN_REV[op_mul], mul_dst, mul_opd1, mul_opd2, self.sig, self.set_flags, cond_mul_str)
+            insn.verbose = MulInstr(enc._MUL_INSN_REV[op_mul], mul_dst, mul_opd1, mul_opd2, sig, self.set_flags, cond_mul_str)
         self.asm._emit(insn, increment=self.increment)
 
 class LoadEmitter(Emitter):

--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -172,8 +172,7 @@ class Emitter(object):
 class AddEmitter(Emitter):
     'Emitter of Add ALU instructions.'
 
-    def _emit(self, op_add, dst=REGISTERS['null'], opd1=REGISTERS['r0'],
-            opd2=REGISTERS['r0'], sig='no signal', set_flags=True, **kwargs):
+    def _emit(self, op_add, dst, opd1, opd2, sig='no signal', set_flags=True, **kwargs):
 
         muxes, raddr_a, raddr_b, use_imm, unpack, read_pm = \
                 self._encode_read_operands(opd1, opd2)
@@ -245,8 +244,7 @@ class MulEmitter(Emitter):
         self.set_flags = set_flags
         self.increment = increment
 
-    def _emit(self, op_mul, mul_dst=REGISTERS['null'], mul_opd1=REGISTERS['r0'],
-            mul_opd2=REGISTERS['r0'], rotate=0, pack='nop', **kwargs):
+    def _emit(self, op_mul, mul_dst, mul_opd1, mul_opd2, rotate=0, pack='nop', **kwargs):
 
         mul_pack = enc._MUL_PACK[pack]
 
@@ -508,11 +506,16 @@ class Assembler(object):
                 insn.verbose = ComposedInstr (add_op.verbose, insn.verbose)
             self._instructions[-1] = insn
 
-    def _emit_add(self, *args, **kwargs):
-        return self._add._emit(*args, **kwargs)
+    # _emit_XXX gives default arguments if needed
+    def _emit_add(self, add_op, *args, **kwargs):
+        l = enc._ADD_DEFAULT_ARGS.get(add_op, [])
+        args = list(args) + l
+        return self._add._emit(add_op, *args, **kwargs)
 
-    def _emit_mul(self, *args, **kwargs):
-        return self._mul._emit(*args, **kwargs)
+    def _emit_mul(self, mul_op, *args, **kwargs):
+        l = enc._MUL_DEFAULT_ARGS.get(mul_op, [])
+        args = list(args) + l
+        return self._mul._emit(mul_op, *args, **kwargs)
 
     def _emit_load(self, *args, **kwargs):
         return self._load._emit(*args, **kwargs)
@@ -574,7 +577,12 @@ for name, code in enc._ADD_INSN.items():
 for name, code in enc._MUL_INSN.items():
     if name not in enc._ADD_INSN:
         setattr(Assembler, name, _partialmethod(Assembler._emit_mul, code))
-    setattr(MulEmitter, name, _partialmethod(MulEmitter._emit, code))
+
+    # XXX bad trick: partial application only for nop in mul
+    if name == 'nop':
+        setattr(MulEmitter, name, _partialmethod(MulEmitter._emit, code, enc._r0, enc._r0, enc._r0))
+    else:
+        setattr(MulEmitter, name, _partialmethod(MulEmitter._emit, code))
 
 for name, code in enc._BRANCH_INSN.items():
     setattr(Assembler, name, _partialmethod(Assembler._emit_branch, code))

--- a/videocore/checker.py
+++ b/videocore/checker.py
@@ -26,79 +26,111 @@ def print_around(instrs, target):
 
 #================ check functions ======================================
 
-def check_branch_delay_slot(instrs):
+def check_branch_delay_slot(instr, instrs, labels):
   f = True
-  for instr in instrs:
-    if (is_branch (instr)):
-      index = instrs.index(instr)
-      if len(instrs) < index + 3:
-        print ('warning: instructions of delay_slot is short?')
-        print_around(instrs, instr)
-        f = False
-      else:
-        delay_slot = instrs[index+1:index+4]
+  if (is_branch (instr)):
+    index = instrs.index(instr)
+    if len(instrs) < index + 3:
+      print ('warning: instructions of delay_slot is short?')
+      print_around(instrs, instr)
+      f = False
+    else:
+      delay_slot = instrs[index+1:index+4]
 
-        for item in delay_slot:
-          if (is_branch (item)):
-            print ('warning: branch is located in the position of delay_slot')
-            print_around(instrs, item)
-            f = False
+      for item in delay_slot:
+        if (is_branch (item)):
+          print ('warning: branch is located in the position of delay_slot')
+          print_around(instrs, item)
+          f = False
 
   return f
 
 # TODO: check signals
 # writing to 'tmu0_s', and sending signal 'load tmu0' make invalid
-def check_composed(instrs):
+def check_composed(instr, instrs, labels):
+  if (is_composed(instr)):
+    v = instr
+    if v.add_instr.dst == v.mul_instr.dst and v.add_instr.sig != 'thread end':
+      print ('warning: dst is the same register in the following composed-instruction')
+      print_around(instrs, instr)
+      return False
+  return True
+
+def get_outputs(instr):
+  outputs = []
+  if is_composed (instr):
+    outputs.append (instr.add_instr.get_dst())
+    outputs.append (instr.mul_instr.get_dst())
+  elif instr.get_dst():
+    outputs.append (instr.get_dst())
+  return filter (lambda x: x != None, outputs)
+
+def get_inputs(instr):
+  inputs = []
+  if is_composed (instr):
+    inputs.append(instr.add_instr.get_arg1())
+    inputs.append(instr.add_instr.get_arg2())
+    inputs.append(instr.mul_instr.get_arg1())
+    inputs.append(instr.mul_instr.get_arg2())
+  else:
+    inputs.append(instr.get_arg1())
+    inputs.append(instr.get_arg2())
+  return filter (lambda x: x != None, inputs)
+
+# return instruction if instr is located in the position of last delay-slot
+def is_in_last_delayslot (instr, instrs, labels):
+  index = instrs.index(instr)
+  if index - 3 < 0:
+    return None
+
+  prev = instrs[index - 3]
+  if is_branch(prev):
+    return instrs[labels[prev.target]]
+  else:
+    return None
+
+def check_regfile(instr, instrs, labels):
   f = True
-  for instr in instrs:
-    if (is_composed(instr)):
-      v = instr
-      if v.add_instr.dst == v.mul_instr.dst and v.add_instr.sig != 'thread end':
-        print ('warning: dst is the same register in the following composed-instruction')
-        print_around(instrs, instr)
+  index = instrs.index(instr)
+
+  if len(instrs) == index + 1:
+    return True
+
+  # prev -> current
+  prev = instr
+  current = is_in_last_delayslot(instr, instrs, labels)
+  show_current = True
+
+  if current:
+    pass
+  else:
+    show_current = False
+    current = instrs[index + 1]
+
+  outputs = get_outputs(prev)
+  inputs = get_inputs(current)
+
+  for out in outputs:
+    for read in inputs:
+      if enc.GENERAL_PURPOSE_REGISTERS.get(out.name, None) and  out.name == read.name:
+        print ('warning: regfile is read next to writing instruction')
+        print_around(instrs, prev)
+        if show_current:
+          print_around(instrs, current)
         f = False
+
   return f
 
-def check_regfile(instrs):
+single_steps = [check_regfile, check_composed, check_branch_delay_slot]
+
+def single_step(instrs, labels):
   f = True
-  if len(instrs) == 1:
-    return
+  for instr in instrs:
+    for check in single_steps:
+      f = f and check (instr, instrs, labels)
+  return f
 
-  for index in range (0, len(instrs) - 1):
-    prev = instrs[index]
-    current = instrs[index+1]
-
-    outputs = []
-    inputs = []
-    def add(list, instr, f):
-      if f(instr) and isinstance (f(instr), Register):
-        list.append(f (instr))
-
-    if is_composed (prev):
-      add (outputs, prev.add_instr, lambda x: x.get_dst())
-      add (outputs, prev.mul_instr, lambda x: x.get_dst())
-    elif prev.get_dst():
-      add (outputs, prev, lambda x: x.get_dst())
-
-    if is_composed (current):
-      add (inputs, current.add_instr, lambda x: x.get_arg1())
-      add (inputs, current.add_instr, lambda x: x.get_arg2())
-      add (inputs, current.mul_instr, lambda x: x.get_arg1())
-      add (inputs, current.mul_instr, lambda x: x.get_arg2())
-    elif current.get_dst():
-      add (inputs, current, lambda x: x.get_arg1())
-      add (inputs, current, lambda x: x.get_arg2())
-
-    for out in outputs:
-      for read in inputs:
-        if enc.GENERAL_PURPOSE_REGISTERS.get(out.name, None) and  out.name == read.name:
-          print ('warning: regfile is read next to writing instruction')
-          print_around(instrs, current)
-          f = False
-
-    return f
-
-all_checks = [check_composed, check_regfile, check_branch_delay_slot]
+all_checks = [single_step]
 
 def extract_verbose(instr):
   return instr.verbose
@@ -107,5 +139,5 @@ def check_main(instrs, labels):
   instrs = list (map(extract_verbose, instrs))
   f = True
   for check in all_checks:
-    f = f and check(instrs)
+    f = f and check(instrs, dict (labels))
   return f

--- a/videocore/encoding.py
+++ b/videocore/encoding.py
@@ -292,6 +292,26 @@ REGISTERS.update(GENERAL_PURPOSE_REGISTERS)
 REGISTERS.update(IO_REGISTERS)
 REGISTERS.update(ACCUMULATORS)
 
+#============================ Default Arguments ============================
+
+
+_r0 = REGISTERS['r0']
+__d = _ADD_INSN
+
+_ADD_DEFAULT_ARGS = {
+    __d['nop']  : [_r0, _r0, _r0],
+    __d['itof'] : [_r0],
+    __d['ftoi'] : [_r0],
+    __d['bnot'] : [_r0],
+    __d['clz']  : [_r0]
+}
+
+__d = _MUL_INSN
+_MUL_DEFAULT_ARGS = {
+    __d['nop'] : [_r0, _r0, _r0]
+}
+
+
 #============================ Instruction encoding ============================
 
 

--- a/videocore/vinstr.py
+++ b/videocore/vinstr.py
@@ -189,7 +189,10 @@ class ComposedInstr(InstrBase):
     assert (False)
 
   def get_sig(self):
-    return self.add_instr.sig
+    if self.add_instr.sig == 'no signal':
+      return self.mul_instr.sig
+    else:
+      return self.add_instr.sig
 
 class Label(InstrBase):
   def __init__(self, name):

--- a/videocore/vinstr.py
+++ b/videocore/vinstr.py
@@ -42,6 +42,9 @@ class InstrBase(object):
   def get_arg2(self):
     return None
 
+  def get_sig(self):
+    return None
+
 class AddInstr(InstrBase):
   def __init__ (self, op, dst, opd1, opd2, sig, set_flag, cond):
     self.op = op
@@ -67,11 +70,13 @@ class AddInstr(InstrBase):
     if self.op == 'nop':
       s = 'nop'
     else :
-      s = '{}, {}, {}, {}'.format(self.op, self.dst, self.opd1, self.opd2)
+      s = '{} {}, {}, {}'.format(self.op, self.dst, self.opd1, self.opd2)
     if self.set_flag:
       s += ' set_flag=True'
     if not (self.cond == 'always'):
-      s += 'cond={}'.format(cond)
+      s += ' cond={}'.format(cond)
+    if not (self.sig == 'no signal'):
+      s += ' sig={}'.format(self.sig)
     return s
 
   def get_dst(self):
@@ -82,6 +87,9 @@ class AddInstr(InstrBase):
 
   def get_arg2(self):
     return self.opd2
+
+  def get_sig(self):
+    return self.sig
 
 class MulInstr(InstrBase):
   def __init__ (self, op, dst, opd1, opd2, sig, set_flag, cond):
@@ -102,6 +110,8 @@ class MulInstr(InstrBase):
       s += ' set_flag=True'
     if not (self.cond == 'always'):
       s += 'cond={}'.format(self.cond)
+    if not (self.sig == 'no signal'):
+      s += ' sig={}'.format(self.sig)
     return s
 
   def get_dst(self):
@@ -112,6 +122,9 @@ class MulInstr(InstrBase):
 
   def get_arg2(self):
     return self.opd2
+
+  def get_sig(self):
+    return self.sig
 
 class LoadImmInstr(InstrBase):
   def __init__(self, reg1, reg2, imm):
@@ -174,6 +187,9 @@ class ComposedInstr(InstrBase):
 
   def get_arg2(self):
     assert (False)
+
+  def get_sig(self):
+    return self.add_instr.sig
 
 class Label(InstrBase):
   def __init__(self, name):


### PR DESCRIPTION
This pullreq add instruction check utilities as follows:

- Check usage of regfile R/W restriction
   Now we can detect such difficult case to see
```python
@qpu
def f(asm):
  L.label1
  mov (r0, ra0) # read from ra0
  jzc(L.label1)
  nop(); nop()
  mov (ra0, 0) # write to ra0, but next instruction write to ra0 !!!
```   

- Check tmu-load restriction
  Instruction that send signal `load tmu0` or `load tmu1` must not write to `tmu_0` and `tmu_1`. This pullreq enable to detect such violations.

- Check sfu-register restriction
  When writing to sfu-registers (like `sfu-log2` or `sfu-exp2`), the following two instruction must not read or write to `r4`. This pullreq enable to detect such violations.

See `test/test_sanity_check.py` to know what this pullreq enable to detect violations.