### PR TITLE
fix namespaced label name

### DIFF
--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -426,7 +426,7 @@ class LabelEmitter(Emitter):
         return label
 
     def __getattr__(self, name):
-        return self[self.asm._generate_label_name(name)]
+        return self[name]
 
 class BranchEmitter(Emitter):
     'Emitter of branch instructions.'


### PR DESCRIPTION
Namespaced label generate redundant label name. This PR fix it.