### PR TITLE
Rotate sanity check

### DIFF
--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -24,6 +24,17 @@ def delay_slot_1(asm):
   exit()
 
 @qpu
+def delay_slot_2(asm):
+  nop()
+  L.label1
+  jzc(reg=ra0)
+  jmp(L.label1)
+  nop()
+  nop()
+  nop()
+  exit()
+
+@qpu
 def regfile_2(asm):
   L.label1
   iadd (r0, ra0, r0)
@@ -37,6 +48,7 @@ def test_sanity_check():
   assert (not sanity_check(regfile_1))
   assert (not sanity_check(composed_1))
   assert (not sanity_check(delay_slot_1))
+  assert (not sanity_check(delay_slot_2))
   assert (not sanity_check(regfile_2))
 
 def test_tmu_reg1():

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -51,6 +51,85 @@ def test_sanity_check():
   assert (not sanity_check(delay_slot_2))
   assert (not sanity_check(regfile_2))
 
+def test_rotate1():
+  @qpu
+  def rotate1(asm):
+    iadd(r0, r0, 1)
+    rotate(r0, r0, -1)
+
+  @qpu
+  def rotate2(asm):
+    imul24(r0, r0, 1)
+    rotate(r0, r0, -1)
+
+  @qpu
+  def rotate3(asm):
+    iadd(r0, r0, 1).imul24(r1, r1, 1)
+    rotate(r0, r0, -1)
+
+  @qpu
+  def rotate4(asm):
+    iadd(r1, r1, 1).imul24(r0, r0, 1)
+    rotate(r0, r0, -1)
+
+  @qpu
+  def rotate5(asm):
+    iadd(r1, r1, 1).imul24(r0, r0, 1)
+    imul24(r0, r0, r0, rotate=-1)
+
+  @qpu
+  def rotate6(asm):
+    iadd(r1, r1, 1).imul24(r0, r0, 1)
+    imul24(r0, r0, r1, rotate=-1)
+
+  @qpu
+  def rotate7(asm):
+    iadd(broadcast, r0, 1)
+    rotate(r0, r0, r5)
+
+  @qpu
+  def rotate8(asm):
+    iadd(ra0, r0, 1)
+    rotate(ra0, ra0, r5)
+
+  @qpu
+  def rotate9(asm):
+    iadd(broadcast, r0, 1)
+    rotate(ra0, ra0, r5)
+
+  @qpu
+  def rotate10(asm):
+    nop()
+    L.label1
+    rotate(r0, r0, -1)
+    jmp(L.label1)
+    nop();nop()
+    mov(r0, 0)
+
+  @qpu
+  def rotate11(asm):
+    L.label1
+    nop()
+    jzc(L.label1)
+    nop();nop()
+    mov(r0, 0)
+    rotate(r0, r0, -1)
+
+  for name, prog in locals().items():
+    assert( not sanity_check(prog))
+def test_rotate2():
+  @qpu
+  def rotate1(asm):
+    rotate(r0, r0, -1)
+
+  @qpu
+  def rotate2(asm):
+    mov(r0, r1)
+    rotate(r1, r1, -1)
+
+  for name, prog in locals().items():
+    assert( sanity_check(prog))
+
 def test_tmu_reg1():
   @qpu
   def tmu_reg1(asm):

--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -337,7 +337,7 @@ class MulEmitter(Emitter):
                 mul_a=muxes[2], mul_b=muxes[3]
                 )
         if self.asm.sanity_check:
-            insn.verbose = MulInstr(enc._MUL_INSN_REV[op_mul], mul_dst, mul_opd1, mul_opd2, sig, self.set_flags, cond_mul_str)
+            insn.verbose = MulInstr(enc._MUL_INSN_REV[op_mul], mul_dst, mul_opd1, mul_opd2, sig, self.set_flags, cond_mul_str, rotate)
         self.asm._emit(insn, increment=self.increment)
 
 class LoadEmitter(Emitter):

--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -478,7 +478,7 @@ class BranchEmitter(Emitter):
             waddr_mul=waddr_mul, immediate=imm
             )
         if self.asm.sanity_check:
-            insn.verbose = BranchInstr(enc._COND_REV[cond_br], target, reg, absolute, link)
+            insn.verbose = BranchInstr(enc._BRANCH_INSN_REV[cond_br], target, reg, absolute, link)
         self.asm._emit(insn)
 
 class SemaEmitter(Emitter):

--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -299,7 +299,7 @@ class MulEmitter(Emitter):
                 raise AssembleError('Rotate operation is only available when'
                                     ' inputs are taken from r0-r4 or ra')
 
-            if use_imm:
+            if raddr_b != REGISTERS['null'].addr:
 
                 # 'r5 rotate' represents -1.
                 # 'n-upward rotate' represents n-16.
@@ -314,10 +314,15 @@ class MulEmitter(Emitter):
 
                 if rotate == REGISTERS['r5']:
                     if raddr_b != enc._SMALL_IMM['-16']:
-                        raise AssembleError(
-                                'Conflict immediate value and r5 rotate')
+                        if use_imm:
+                            raise AssembleError('Conflict immediate value and r5 rotate')
+                        else:
+                            raise AssembleError('Conflict of regfile B source operand and rotate')
                 elif raddr_b != enc._SMALL_IMM[str(rotate%16-16)]:
-                    raise AssembleError('Conflict immediate value and n rotate')
+                    if use_imm:
+                        raise AssembleError('Conflict immediate value and n rotate')
+                    else:
+                        raise AssembleError('Conflict of regfile B source operand and rotate')
 
             if rotate == REGISTERS['r5']:
                 raddr_b = 48

--- a/videocore/checker.py
+++ b/videocore/checker.py
@@ -78,8 +78,8 @@ def is_in_last_delayslot (instr, instrs, labels):
     return None
 
   prev = instrs[index - 3]
-  if is_branch(prev):
-    return instrs[labels[prev.target.name]]
+  if is_branch(prev) and prev.target: # destination may not be a label
+    return instrs[labels[prev.target.name]//8]
   else:
     return None
 
@@ -166,9 +166,9 @@ def check_regfile(instr, instrs, labels):
   outputs = get_outputs(prev)
   inputs = get_inputs(current)
 
-  for out in outputs:
-    for read in inputs:
-      if enc.GENERAL_PURPOSE_REGISTERS.get(out.name, None) and  out.name == read.name:
+  for out in list (filter(is_register, outputs)):
+    for read in list (filter(is_register, inputs)):
+      if enc.GENERAL_PURPOSE_REGISTERS.get(out.name, None) and out.name == read.name:
         print ('warning: regfile is read next to writing instruction')
         print_around(prev, instrs, labels)
         if show_current:

--- a/videocore/vinstr.py
+++ b/videocore/vinstr.py
@@ -74,7 +74,7 @@ class AddInstr(InstrBase):
     if self.set_flag:
       s += ' set_flag=True'
     if not (self.cond == 'always'):
-      s += ' cond={}'.format(cond)
+      s += ' cond={}'.format(self.cond)
     if not (self.sig == 'no signal'):
       s += ' sig={}'.format(self.sig)
     return s
@@ -109,7 +109,7 @@ class MulInstr(InstrBase):
     if self.set_flag:
       s += ' set_flag=True'
     if not (self.cond == 'always'):
-      s += 'cond={}'.format(self.cond)
+      s += ' cond={}'.format(self.cond)
     if not (self.sig == 'no signal'):
       s += ' sig={}'.format(self.sig)
     return s
@@ -157,7 +157,12 @@ class BranchInstr(InstrBase):
     self.link = link
 
   def __str__(self):
-    return '{}(L.{})'.format(self.cond_br, self.target.name)
+    s = self.cond_br
+    if self.target:
+      s += '(L.{})'.format(self.target.name)
+    else:
+      s += link
+    return s
 
 class SemaInstr(InstrBase):
   def __init__(self, sa, sema_id):

--- a/videocore/vinstr.py
+++ b/videocore/vinstr.py
@@ -33,6 +33,9 @@ class InstrBase(object):
   def __init__():
     return
 
+  def is_nop(self):
+    return False
+
   def get_dst(self):
     return None
 
@@ -79,6 +82,9 @@ class AddInstr(InstrBase):
       s += ' sig={}'.format(self.sig)
     return s
 
+  def is_nop(self):
+    return self.op == 'nop'
+
   def get_dst(self):
     return self.dst
 
@@ -92,7 +98,7 @@ class AddInstr(InstrBase):
     return self.sig
 
 class MulInstr(InstrBase):
-  def __init__ (self, op, dst, opd1, opd2, sig, set_flag, cond):
+  def __init__ (self, op, dst, opd1, opd2, sig, set_flag, cond, rotate):
     self.op = op
     self.dst = dst
     self.opd1 = opd1
@@ -100,6 +106,7 @@ class MulInstr(InstrBase):
     self.sig = sig
     self.set_flag = set_flag
     self.cond = cond
+    self.rotate = rotate
 
   def __str__(self):
     if self.op == 'nop':
@@ -112,7 +119,15 @@ class MulInstr(InstrBase):
       s += ' cond={}'.format(self.cond)
     if not (self.sig == 'no signal'):
       s += ' sig={}'.format(self.sig)
+    if self.rotate:
+      s += ' rotate={}'.format(self.rotate)
     return s
+
+  def get_rotate(self):
+    return self.rotate
+
+  def is_nop(self):
+    return self.op == 'nop'
 
   def get_dst(self):
     return self.dst


### PR DESCRIPTION
# bugfix for sanity check
* calculation of branch label in sanity check was wrong
* sanity check for branch instruction got instruction kind from wrong table
* `check_regfile` aborted when its read operand is small immediate
* when a register is used for branch address, `BranchInstr.__str__` aborted

# rotate sanity check
Added sanity check for below 2 cases, described in "Summary of Instruction Restrictions" in VideoCore IV Architecture Guide.
* An instruction that does a vector rotate by r5 must not immediately follow an instruction that writes to r5.
* An instruction that does a vector rotate must not immediately follow an instruction that writes to the
accumulator that is being rotated.

# conflict check for regfileB and rotate
Added check for below invalid case.
`iadd(r0, rb0, r0).rotate(r1, r1, -1)`