### PR TITLE
add get_throttled plus examples

### DIFF
--- a/examples/mailbox.py
+++ b/examples/mailbox.py
@@ -1,7 +1,10 @@
 from videocore.mailbox import MailBox
 
 with MailBox() as mb:
-    print('firmware revision: %x' % mb.get_firmware_revision())
-    print('board model: %x' % mb.get_board_model())
-    print('board revision: %x' % mb.get_board_revision())
-    print('board serial: %016x' % mb.get_board_serial())
+    print('firmware revision: {:x}'.format(mb.get_firmware_revision()))
+    print('board model:       {:x}'.format(mb.get_board_model()))
+    print('board revision:    {:x}'.format(mb.get_board_revision()))
+    print('board serial:      {:016x}'.format(mb.get_board_serial()))
+    print('temperature:       {:.2f}'.format(float(mb.get_temperature(0)[1])/1000.0))
+    print('max temperature:   {:.2f}'.format(float(mb.get_max_temperature(0)[1])/1000.0))
+    print('throttled:         {:#x}'.format( int(mb.get_throttled() )))

--- a/videocore/mailbox.py
+++ b/videocore/mailbox.py
@@ -221,7 +221,8 @@ MAILBOX_METHODS = [
     ('get_palette',                      0x0004000b,  '',     '1024s'),     
     ('get_dma_channels',                 0x00060001,  '',     ''),     
     ('set_cursor_state',                 0x00008010,  '4L',   'L'),     
-    ('set_cursor_info',                  0x00008011,  '6L',   'L'),     
+    ('set_cursor_info',                  0x00008011,  '6L',   'L'),
+    ('get_throttled',                    0x00030046,  '',     'L'),
     ]
 
 for name, tag, req_fmt, res_fmt in MAILBOX_METHODS:


### PR DESCRIPTION
Really had to dig around/ask around to find the magic code for get_throttled. [pi god popcornmix pointed me to it](https://github.com/raspberrypi/firmware/issues/1037), and I [also found the header file `raspberrypi-formware.h`](https://github.com/raspberrypi/linux/blob/rpi-4.14.y/include/soc/bcm2835/raspberrypi-firmware.h#L80) that defines the codes.

added a couple examples showing format conversions and updated the python to the more modern formatter.