### PR TITLE
add error check in case ldi is used with other signal

### DIFF
--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -409,6 +409,10 @@ class LoadEmitter(Emitter):
             reg2 = args[1]
             imm = args[2]
 
+        sig = kwargs.get('sig', 'load')
+        if sig != 'load':
+            raise AssembleError('Conflict of signals')
+
         waddr_add, waddr_mul, write_swap, pack = \
                 self._encode_write_operands(reg1, reg2)
 


### PR DESCRIPTION
The signal was ignored silently in below wrong instruction.
With this modification below instruction become an assemble error.
`ldi(reg, n, sig='xxx')`