### PR TITLE
Fix qpu decorator not to override the original function name and doc

### DIFF
--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -11,7 +11,7 @@ The QPU instruction set is described in the section 3 of the following document
 
 from __future__ import print_function
 import sys
-from functools import partial
+from functools import partial, wraps
 from struct import pack, unpack
 import inspect
 import ast
@@ -859,6 +859,7 @@ def qpu(f):
         raise AssembleError('Argument named \'asm\' is necessary')
 
     def decorate(f):
+        @wraps(f)
         def decorated(asm, *args, **kwargs):
             g = f.__globals__
             for reg in Assembler._REGISTERS:


### PR DESCRIPTION
Without [`functools.wraps`](https://docs.python.org/3/library/functools.html#functools.wraps), the name and the doc of a function to be decorated will be lost.  This PR fixes that.

Example code:

```python3
#!/usr/bin/env python3

from videocore.assembler import qpu

@qpu
def qpu_code(asm):
    nop()
    exit(interrupt = True)

print(qpu_code.__name__)
```

Before the change in this PR, the code prints `decorated`, which is the name of the decorator.  After the change, the output will be `qpu_code`, which is desired.