### PR TITLE
Add raw_program function

### DIFF
--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -3,6 +3,7 @@
 import io
 import numpy as np
 from random import getrandbits
+from ctypes import create_string_buffer
 
 from videocore.assembler import qpu, print_qhex
 from videocore.driver import Driver
@@ -11,7 +12,17 @@ from videocore.driver import Driver
 def raw_hex(asm):
     raw(0xDEADBEEF, 0xFEEDFACE)
 
+@qpu
+def raw_program_hex(asm):
+    data = b'\xEF\xBE\xAD\xDE\xCE\xFA\xED\xFE\xBE\xBE\xFE\xCA\x0D\xF0\xDD\xBA'
+    raw_program(create_string_buffer(data, len(data)), len(data))
+
 def test_raw_hex():
     f = io.StringIO()
     print_qhex(raw_hex, file = f)
     assert f.getvalue().rstrip() == '0xDEADBEEF, 0xFEEDFACE,'
+
+def test_raw_program():
+    f = io.StringIO()
+    print_qhex(raw_program_hex, file = f)
+    assert f.getvalue().rstrip() == '0xDEADBEEF, 0xFEEDFACE,\n0xCAFEBEBE, 0xBADDF00D,'

--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -515,6 +515,13 @@ class RawEmitter(Emitter):
         insn = enc.RawInsn(raw1 = val1, raw2 = val2)
         self.asm._emit(insn)
 
+class RawProgramEmitter(Emitter):
+    'Emitter of raw whole program. (DANGER)'
+
+    def _emit(self, val, size):
+        prog = enc.RawProgram(raw = val, size = size)
+        self.asm._emit(prog)
+
 class LabelNameSpace(object):
     'Label namespace controller.'
 
@@ -551,6 +558,7 @@ class Assembler(object):
         self._branch = BranchEmitter(self)
         self._sema = SemaEmitter(self)
         self._raw = RawEmitter(self)
+        self._raw_program = RawProgramEmitter(self)
         self.L = LabelEmitter(self)
 
         self.namespace = lambda ns: LabelNameSpace(self, ns)
@@ -588,6 +596,9 @@ class Assembler(object):
 
     def _emit_raw(self, *args, **kwargs):
         return self._raw._emit(*args, **kwargs)
+
+    def _emit_raw_program(self, *args, **kwargs):
+        return self._raw_program._emit(*args, **kwargs)
 
     def _add_label(self, label):
         self._labels.append((label, self._program_counter))
@@ -827,6 +838,10 @@ def sema_down(asm, sema_id):
 @alias
 def raw(asm, val1, val2):
     asm._emit_raw(val1, val2);
+
+@alias
+def raw_program(asm, val, size):
+    asm._emit_raw_program(val, size)
 
 def qpu(f):
     """Decorator for writing QPU assembly language.

--- a/videocore/encoding.py
+++ b/videocore/encoding.py
@@ -1,4 +1,4 @@
-from ctypes import Structure, c_ulong, string_at, byref, sizeof
+from ctypes import Structure, c_ulong, string_at, byref, sizeof, c_char, c_size_t, POINTER
 from struct import pack, unpack
 
 class AssembleError(Exception):
@@ -386,3 +386,11 @@ class SemaInsn(Insn):
 
 class RawInsn(Insn):
     _fields_ = [ (f, c_ulong, n) for f, n in [('raw1', 32), ('raw2', 32)] ]
+
+class RawProgram(Insn):
+    _fields_ = [('raw', POINTER(c_char)), ('size', c_size_t)]
+
+    def to_bytes(self):
+        'Encode instruction to string.'
+        return string_at(self.raw, self.size)
+


### PR DESCRIPTION
`raw_program` emits entire binary code. This is a example code.

```python
@qpu
def sigmoid(asm):
    with open('sigmoid.bin', 'rb') as f:
        from ctypes import pointer, create_string_buffer
        data = f.read()
        raw_program(create_string_buffer(data, len(data)), len(data))
```