### PR TITLE
Fix warning

### DIFF
--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -868,7 +868,7 @@ def qpu(f):
 
             asm.exit()
     """
-    args, _, _, _ = inspect.getargspec(f)
+    args = inspect.signature(f).parameters
 
     if 'asm' not in args:
         raise AssembleError('Argument named \'asm\' is necessary')


### PR DESCRIPTION
Fix the below warning.

```
videocore/assembler.py:871: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
    args, _, _, _ = inspect.getargspec(f)
```
