### PR TITLE
Fix indent in videocore/assembler.py

### DIFF
--- a/videocore/assembler.py
+++ b/videocore/assembler.py
@@ -920,8 +920,8 @@ def print_qbin(program, file = sys.stdout, *args, **kwargs):
     'Print QPU program as .qbin.'
     if hasattr(program, '__call__'):
         program = assemble(program, *args, **kwargs)
-        code = memoryview(program).tobytes()
-        code = map(ord, code) if type(code) is str else code
+    code = memoryview(program).tobytes()
+    code = map(ord, code) if type(code) is str else code
     assert(len(code) % 8 == 0)
     for i in range(len(code) // 8):
         for j in range(7, -1, -1):
@@ -932,8 +932,8 @@ def print_qhex(program, file = sys.stdout, *args, **kwargs):
     'Print QPU program as .qhex.'
     if hasattr(program, '__call__'):
         program = assemble(program, *args, **kwargs)
-        code = memoryview(program).tobytes()
-        code = map(ord, code) if type(code) is str else code
+    code = memoryview(program).tobytes()
+    code = map(ord, code) if type(code) is str else code
     assert(len(code) % 8 == 0)
     for c in zip(*[iter(code)]*8):
         print("0x{3:02X}{2:02X}{1:02X}{0:02X}, 0x{7:02X}{6:02X}{5:02X}{4:02X},".format(*c), file = file)
@@ -942,8 +942,8 @@ def save_bin(program, file, *args, **kwargs):
     'Save QPU program as .bin.'
     if hasattr(program, '__call__'):
         program = assemble(program, *args, **kwargs)
-        code = memoryview(program).tobytes()
-        code = map(ord, code) if type(code) is str else code
+    code = memoryview(program).tobytes()
+    code = map(ord, code) if type(code) is str else code
     assert(len(code) % 8 == 0)
     with open(file, 'wb') as f:
         f.write(code)


### PR DESCRIPTION
`print_qbin`, `print_qhex` and `save_bin` methods in `assembler.py` will run successfully if `hasattr(program, '__call__')` condition is met.
Otherwise, they will raise `UnboundLocalError: local variable 'code' referenced before assignment` error.

This pull request fixes these indents to ensure the local variable `code` is defined.